### PR TITLE
Address CodeQL workflow build detection and add MIT license

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -10,7 +10,30 @@ on:
     - cron: '0 6 * * 1'
 
 jobs:
+  detect-build:
+    name: Detect build configuration
+    runs-on: ubuntu-latest
+    outputs:
+      has-build: ${{ steps.detect.outputs.has-build }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Check for Swift build definition
+        id: detect
+        run: |
+          XCODE_PROJECTS=$(git ls-files '*.xcodeproj' | wc -l)
+          SWIFTPM_FILES=$(git ls-files 'Package.swift' | wc -l)
+          if [ "$XCODE_PROJECTS" -gt 0 ] || [ "$SWIFTPM_FILES" -gt 0 ]; then
+            echo "has-build=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "has-build=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::No Xcode project or Package.swift file detected; skipping CodeQL analysis until a build configuration is available."
+          fi
+
   analyze:
+    needs: detect-build
+    if: ${{ needs.detect-build.outputs.has-build == 'true' }}
     name: Analyze Code
     runs-on: macos-latest
     permissions:

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 Astrion Studio
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
## Summary
- add a build-detection job so the CodeQL workflow skips when no Swift project or Package.swift is present
- keep the analysis job gated on the detection result to avoid permanent failures
- add the MIT LICENSE file referenced by the README

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68f5546c3270832f9174a3176b93a650