### PR TITLE
Address Codex review feedback for CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,8 +33,8 @@ jobs:
       
       - name: Check for print statements
         run: |
-          PRINT_STATEMENTS=$(find ios-app/FareLens -name "*.swift" -type f ! -name "*Tests.swift" \
-            -exec grep -l 'print(' {} + 2>/dev/null || true)
+          PRINT_STATEMENTS=$(find ios-app/FareLens -name "*.swift" -type f ! -name "*Tests.swift" -print0 | \
+            xargs -0 grep -l 'print(' 2>/dev/null || true)
 
           if [ -n "$PRINT_STATEMENTS" ]; then
             echo "❌ Found print statements (use OSLog instead)"
@@ -89,6 +89,7 @@ jobs:
       - name: Run tests
         if: steps.check_project.outputs.has_project == 'true'
         run: |
+          set -euo pipefail
           cd ios-app
           xcodebuild test -scheme FareLens -destination 'platform=iOS Simulator,name=iPhone 15 Pro'
 


### PR DESCRIPTION
## Summary
- replace the print statement scan with a macOS-compatible find/xargs pipeline so the job no longer depends on GNU grep flags

## Testing
- not run (workflow change only)

------
https://chatgpt.com/codex/tasks/task_e_68f551d832e8832f9c6920a032624831