### PR TITLE
fix: Fix Date serialization crash in watchlist API endpoints

### DIFF
--- a/ios-app/FareLens/Data/Networking/APIEndpoint.swift
+++ b/ios-app/FareLens/Data/Networking/APIEndpoint.swift
@@ -58,31 +58,55 @@ extension APIEndpoint {
     }
 
     static func createWatchlist(_ watchlist: Watchlist) -> APIEndpoint {
-        APIEndpoint(
+        var body: [String: Any] = [
+            "name": watchlist.name,
+            "origin": watchlist.origin,
+            "destination": watchlist.destination,
+        ]
+
+        if let dateRange = watchlist.dateRange {
+            let iso8601 = ISO8601DateFormatter()
+            body["date_range"] = [
+                "start": iso8601.string(from: dateRange.start),
+                "end": iso8601.string(from: dateRange.end),
+            ]
+        }
+
+        if let maxPrice = watchlist.maxPrice {
+            body["max_price"] = maxPrice
+        }
+
+        return APIEndpoint(
             path: "/watchlists",
             method: .post,
-            body: [
-                "name": watchlist.name,
-                "origin": watchlist.origin,
-                "destination": watchlist.destination,
-                "date_range": watchlist.dateRange.map { ["start": $0.start, "end": $0.end] } as Any,
-                "max_price": watchlist.maxPrice as Any,
-            ]
+            body: body
         )
     }
 
     static func updateWatchlist(id: UUID, watchlist: Watchlist) -> APIEndpoint {
-        APIEndpoint(
+        var body: [String: Any] = [
+            "name": watchlist.name,
+            "origin": watchlist.origin,
+            "destination": watchlist.destination,
+            "is_active": watchlist.isActive,
+        ]
+
+        if let dateRange = watchlist.dateRange {
+            let iso8601 = ISO8601DateFormatter()
+            body["date_range"] = [
+                "start": iso8601.string(from: dateRange.start),
+                "end": iso8601.string(from: dateRange.end),
+            ]
+        }
+
+        if let maxPrice = watchlist.maxPrice {
+            body["max_price"] = maxPrice
+        }
+
+        return APIEndpoint(
             path: "/watchlists/\(id.uuidString)",
             method: .put,
-            body: [
-                "name": watchlist.name,
-                "origin": watchlist.origin,
-                "destination": watchlist.destination,
-                "date_range": watchlist.dateRange.map { ["start": $0.start, "end": $0.end] } as Any,
-                "max_price": watchlist.maxPrice as Any,
-                "is_active": watchlist.isActive,
-            ]
+            body: body
         )
     }
 


### PR DESCRIPTION
## Summary
**CRITICAL BUG FIX** - This would have caused runtime crashes when creating/updating watchlists

### Problem
- Date objects were being serialized directly into JSONSerialization
- Would crash with: `"Invalid type in JSON write (Date)"`
- Affected `createWatchlist()` and `updateWatchlist()` endpoints

### Solution
- Convert Date objects to ISO8601 strings before serialization
- Properly handle optional `dateRange` and `maxPrice`
- Use conditional logic instead of force-unwrapping optionals as Any

### Changes in [APIEndpoint.swift](ios-app/FareLens/Data/Networking/APIEndpoint.swift)
- `createWatchlist`: Lines 60-84 - Convert dateRange.start/end to ISO8601
- `updateWatchlist`: Lines 86-111 - Convert dateRange.start/end to ISO8601

## Fixes
Addresses Codex finding: Date serialization bug at lines 65, 82

## Test Plan
- [ ] Create watchlist with date range - no crash
- [ ] Create watchlist without date range - no crash
- [ ] Update watchlist with date range - no crash
- [ ] Update watchlist without date range - no crash

🤖 Generated with [Claude Code](https://claude.com/claude-code)