### PR TITLE
Ensure notification delegate runs on main actor

### DIFF
--- a/ios-app/FareLens/Core/Services/NotificationService.swift
+++ b/ios-app/FareLens/Core/Services/NotificationService.swift
@@ -12,7 +12,7 @@ protocol NotificationServiceProtocol {
     func sendDealAlert(deal: FlightDeal, userId: UUID) async
 }
 
-actor NotificationService: NSObject, NotificationServiceProtocol, UNUserNotificationCenterDelegate {
+@MainActor final class NotificationService: NSObject, NotificationServiceProtocol, UNUserNotificationCenterDelegate {
     static let shared = NotificationService()
 
     private let notificationCenter = UNUserNotificationCenter.current()
@@ -105,7 +105,7 @@ actor NotificationService: NSObject, NotificationServiceProtocol, UNUserNotifica
 
     // MARK: - UNUserNotificationCenterDelegate
 
-    nonisolated func userNotificationCenter(
+    func userNotificationCenter(
         _: UNUserNotificationCenter,
         willPresent _: UNNotification
     ) async -> UNNotificationPresentationOptions {
@@ -113,7 +113,7 @@ actor NotificationService: NSObject, NotificationServiceProtocol, UNUserNotifica
         [.banner, .sound, .badge]
     }
 
-    nonisolated func userNotificationCenter(
+    func userNotificationCenter(
         _: UNUserNotificationCenter,
         didReceive response: UNNotificationResponse
     ) async {


### PR DESCRIPTION
## Summary
- annotate `NotificationService` as a `@MainActor` `final class` while retaining the singleton
- remove `nonisolated` from the notification center delegate methods so they execute on the main actor

## Testing
- not run (xcodebuild unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68f6d22e19cc832fb6f36d8247b20b45