### PR TITLE
Add UIKit imports to SwiftUI feature files

### DIFF
--- a/ios-app/FareLens/Features/Deals/DealDetailViewModel.swift
+++ b/ios-app/FareLens/Features/Deals/DealDetailViewModel.swift
@@ -4,6 +4,7 @@
 import Foundation
 import Observation
 import SwiftUI
+import UIKit
 
 @Observable
 @MainActor

--- a/ios-app/FareLens/Features/Settings/NotificationSettingsView.swift
+++ b/ios-app/FareLens/Features/Settings/NotificationSettingsView.swift
@@ -3,6 +3,7 @@
 
 import Observation
 import SwiftUI
+import UIKit
 import UserNotifications
 
 struct NotificationSettingsView: View {

--- a/ios-app/FareLens/Features/Subscription/PaywallView.swift
+++ b/ios-app/FareLens/Features/Subscription/PaywallView.swift
@@ -4,6 +4,7 @@
 import Observation
 import StoreKit
 import SwiftUI
+import UIKit
 
 struct PaywallView: View {
     @State private var viewModel = PaywallViewModel()


### PR DESCRIPTION
## Summary
- add UIKit imports to the deal detail view model to support UIApplication usage
- add UIKit import to the paywall view alongside existing frameworks
- update notification settings view to import UIKit for notification permission helpers

## Testing
- xcodebuild -workspace ios-app/FareLens.xcworkspace -scheme FareLens -sdk iphonesimulator -configuration Debug build *(fails: `xcodebuild` not available in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68f6d30631ac832fbda0787e4e222ff3