### PR TITLE
Adjust notification handling to run on main actor

### DIFF
--- a/ios-app/FareLens/Core/Services/NotificationService.swift
+++ b/ios-app/FareLens/Core/Services/NotificationService.swift
@@ -12,7 +12,7 @@ protocol NotificationServiceProtocol {
     func sendDealAlert(deal: FlightDeal, userId: UUID) async
 }
 
-actor NotificationService: NSObject, NotificationServiceProtocol, UNUserNotificationCenterDelegate {
+@MainActor final class NotificationService: NSObject, NotificationServiceProtocol, UNUserNotificationCenterDelegate {
     static let shared = NotificationService()
 
     private let notificationCenter = UNUserNotificationCenter.current()
@@ -105,7 +105,7 @@ actor NotificationService: NSObject, NotificationServiceProtocol, UNUserNotifica
 
     // MARK: - UNUserNotificationCenterDelegate
 
-    nonisolated func userNotificationCenter(
+    func userNotificationCenter(
         _: UNUserNotificationCenter,
         willPresent _: UNNotification
     ) async -> UNNotificationPresentationOptions {
@@ -113,7 +113,7 @@ actor NotificationService: NSObject, NotificationServiceProtocol, UNUserNotifica
         [.banner, .sound, .badge]
     }
 
-    nonisolated func userNotificationCenter(
+    func userNotificationCenter(
         _: UNUserNotificationCenter,
         didReceive response: UNNotificationResponse
     ) async {


### PR DESCRIPTION
## Summary
- mark `NotificationService` as a `@MainActor`-isolated class instead of an actor
- remove unnecessary `nonisolated` modifiers from notification delegate callbacks

## Testing
- not run (xcodebuild unavailable in container)

------
https://chatgpt.com/codex/tasks/task_e_68f6d8d2d628832f9a6791e9069d02b1