### PR TITLE
Fix NotificationService compile regression

### DIFF
--- a/ios-app/FareLens/Core/Services/NotificationService.swift
+++ b/ios-app/FareLens/Core/Services/NotificationService.swift
@@ -12,7 +12,8 @@ protocol NotificationServiceProtocol {
     func sendDealAlert(deal: FlightDeal, userId: UUID) async
 }
 
-actor NotificationService: NSObject, NotificationServiceProtocol, UNUserNotificationCenterDelegate {
+@MainActor
+final class NotificationService: NSObject, NotificationServiceProtocol, UNUserNotificationCenterDelegate {
     static let shared = NotificationService()
 
     private let notificationCenter = UNUserNotificationCenter.current()
@@ -105,7 +106,7 @@ actor NotificationService: NSObject, NotificationServiceProtocol, UNUserNotifica
 
     // MARK: - UNUserNotificationCenterDelegate
 
-    nonisolated func userNotificationCenter(
+    func userNotificationCenter(
         _: UNUserNotificationCenter,
         willPresent _: UNNotification
     ) async -> UNNotificationPresentationOptions {
@@ -113,7 +114,7 @@ actor NotificationService: NSObject, NotificationServiceProtocol, UNUserNotifica
         [.banner, .sound, .badge]
     }
 
-    nonisolated func userNotificationCenter(
+    func userNotificationCenter(
         _: UNUserNotificationCenter,
         didReceive response: UNNotificationResponse
     ) async {


### PR DESCRIPTION
## Summary
- convert `NotificationService` into a `@MainActor` class so it can still subclass `NSObject`
- drop `nonisolated` annotations from delegate callbacks since the type is no longer an actor

## Testing
- not run (not supported in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68f6c73ec434832fb3e24302bec86890