### PR TITLE
fix: Apply origin filter to API fetch results in DealsRepository

### DIFF
--- a/ios-app/FareLens/Data/Repositories/DealsRepository.swift
+++ b/ios-app/FareLens/Data/Repositories/DealsRepository.swift
@@ -45,10 +45,13 @@ actor DealsRepository: DealsRepositoryProtocol {
         let endpoint = APIEndpoint.getDeals(origin: origin)
         let response: DealsResponse = try await apiClient.request(endpoint)
 
-        // Cache deals
-        await persistenceService.saveDeals(response.deals)
+        // Filter deals by origin before caching and returning
+        let filteredDeals = filterByOrigin(response.deals, origin: origin)
 
-        return response.deals
+        // Cache filtered deals
+        await persistenceService.saveDeals(filteredDeals)
+
+        return filteredDeals
     }
 
     /// Fetch single deal detail


### PR DESCRIPTION
Fixes #61

## Problem

DealsRepository.fetchDeals(origin:) returned unfiltered API results,
ignoring the origin parameter. When users applied an origin filter,
cached results filtered correctly but fresh API fetches showed all
deals from all airports.

## Solution

Pipe API response through filterByOrigin() before caching and returning:

- Filter response.deals by origin parameter
- Cache only filtered results (not all deals)
- Return filtered deals to match cache behavior

## Impact

- Deals tab now correctly shows only deals from preferred airport
- Both cache and API code paths behave consistently
- Fixes user experience issue where wrong routes appeared

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>
