### PR TITLE
Fix SmartQueueService test setup for Swift 6 concurrency

### DIFF
--- a/ios-app/FareLensTests/SmartQueueServiceTests.swift
+++ b/ios-app/FareLensTests/SmartQueueServiceTests.swift
@@ -6,7 +6,7 @@ final class SmartQueueServiceTests: XCTestCase {
     var testUser: User!
 
     override func setUp() async throws {
-        sut = SmartQueueService()
+        sut = await MainActor.run { SmartQueueService() }
         testUser = createTestUser()
     }
 


### PR DESCRIPTION
## Summary
- ensure SmartQueueServiceTests instantiates SmartQueueService from the main actor to align with Swift 6 concurrency rules

## Testing
- not run (not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68f718dffee4832f90531fe6ff09574b