### PR TITLE
Fix onboarding bindings for observable view model

### DIFF
--- a/ios-app/FareLens/Features/Onboarding/OnboardingView.swift
+++ b/ios-app/FareLens/Features/Onboarding/OnboardingView.swift
@@ -1,6 +1,7 @@
 // FareLens - Flight Deal Alert App
 // Copyright © 2025 FareLens. All rights reserved.
 
+import Observation
 import SwiftUI
 
 struct OnboardingView: View {
@@ -29,7 +30,7 @@ struct OnboardingView: View {
 }
 
 struct WelcomeScreen: View {
-    var viewModel: OnboardingViewModel
+    @Bindable var viewModel: OnboardingViewModel
 
     var body: some View {
         ZStack {
@@ -75,7 +76,7 @@ struct WelcomeScreen: View {
 }
 
 struct BenefitsScreen: View {
-    var viewModel: OnboardingViewModel
+    @Bindable var viewModel: OnboardingViewModel
 
     var body: some View {
         ZStack {
@@ -181,7 +182,7 @@ struct BenefitRow: View {
 }
 
 struct AuthScreen: View {
-    var viewModel: OnboardingViewModel
+    @Bindable var viewModel: OnboardingViewModel
     @State private var isSignUp = false
 
     var body: some View {


### PR DESCRIPTION
## Summary
- import the Observation framework in the onboarding view
- mark onboarding subviews with @Bindable so text fields can bind to observable state

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68f72279b6d4832fa8e3c6444edefd90