### PR TITLE
Expose WatchlistsViewModel user ID for watchlist creation

### DIFF
--- a/ios-app/FareLens/Features/Watchlists/CreateWatchlistView.swift
+++ b/ios-app/FareLens/Features/Watchlists/CreateWatchlistView.swift
@@ -172,7 +172,7 @@ struct CreateWatchlistView: View {
 
     private func saveWatchlist() {
         let watchlist = Watchlist(
-            userId: viewModel.user.id,
+            userId: viewModel.userId,
             name: name,
             origin: origin.uppercased(),
             destination: isFlexibleDestination ? "ANY" : destination.uppercased(),

--- a/ios-app/FareLens/Features/Watchlists/WatchlistsViewModel.swift
+++ b/ios-app/FareLens/Features/Watchlists/WatchlistsViewModel.swift
@@ -19,6 +19,10 @@ final class WatchlistsViewModel {
         self.user = user
     }
 
+    var userId: UUID {
+        user.id
+    }
+
     var canAddWatchlist: Bool {
         watchlists.count < user.maxWatchlists
     }


### PR DESCRIPTION
## Summary
- add a public `userId` accessor to `WatchlistsViewModel` while keeping the underlying `User` private
- update `CreateWatchlistView` to use the new accessor when creating a watchlist, resolving the access control error

## Testing
- not run (not available in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68f72e0ba2b8832fad7db0a87687af0e