### PR TITLE
Remove unused SceneDelegate configuration

### DIFF
--- a/ios-app/FareLens/Resources/Info.plist
+++ b/ios-app/FareLens/Resources/Info.plist
@@ -68,18 +68,6 @@
     <dict>
         <key>UIApplicationSupportsMultipleScenes</key>
         <false/>
-        <key>UISceneConfigurations</key>
-        <dict>
-            <key>UIWindowSceneSessionRoleApplication</key>
-            <array>
-                <dict>
-                    <key>UISceneConfigurationName</key>
-                    <string>Default Configuration</string>
-                    <key>UISceneDelegateClassName</key>
-                    <string>$(PRODUCT_MODULE_NAME).SceneDelegate</string>
-                </dict>
-            </array>
-        </dict>
     </dict>
 
     <!-- Required Device Capabilities -->


### PR DESCRIPTION
## Summary
- remove the UISceneDelegateClassName reference from the iOS Info.plist
- delete the unused scene configuration dictionary now that the SwiftUI App entry point is used

## Testing
- not run (xcodebuild unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68f80d741a60832f85573938b2b03b7f