### PR TITLE
Restore API auth token during optimistic launch and mock auth in onboarding tests

### DIFF
--- a/ios-app/FareLens/App/AppState.swift
+++ b/ios-app/FareLens/App/AppState.swift
@@ -51,6 +51,10 @@ final class AppState {
 
         // Phase 1: INSTANT - Load cached auth state (< 100ms)
         if let cachedUser = await PersistenceService.shared.loadUser() {
+            // Restore stored auth token immediately so API requests include credentials
+            let storedToken = await AuthService.shared.getAuthToken()
+            await APIClient.shared.setAuthToken(storedToken)
+
             // Optimistically show as authenticated
             currentUser = cachedUser
             isAuthenticated = true

--- a/ios-app/FareLens/Features/Onboarding/OnboardingViewModel.swift
+++ b/ios-app/FareLens/Features/Onboarding/OnboardingViewModel.swift
@@ -21,9 +21,11 @@ final class OnboardingViewModel {
     var serverError: ServerError?
 
     private let appState: AppState
+    private let authService: AuthServiceProtocol
 
-    init(appState: AppState) {
+    init(appState: AppState, authService: AuthServiceProtocol = AuthService.shared) {
         self.appState = appState
+        self.authService = authService
     }
 
     var isFormValid: Bool {
@@ -108,7 +110,7 @@ final class OnboardingViewModel {
         serverError = nil
 
         do {
-            let user = try await AuthService.shared.signIn(email: email, password: password)
+            let user = try await authService.signIn(email: email, password: password)
             isLoading = false
 
             // Success haptic
@@ -135,7 +137,7 @@ final class OnboardingViewModel {
         serverError = nil
 
         do {
-            let user = try await AuthService.shared.signUp(email: email, password: password)
+            let user = try await authService.signUp(email: email, password: password)
             isLoading = false
 
             // Success haptic


### PR DESCRIPTION
## Summary
- restore the persisted JWT on app launch so API requests include credentials during optimistic authentication
- inject an `AuthServiceProtocol` dependency into `OnboardingViewModel` for easier mocking
- update the onboarding view model tests to use a mock auth service instead of the live singleton

## Testing
- Not run (iOS tooling unavailable in this environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690e6b621e14832f99403bce405f6d37)