### PR TITLE
Ensure cached sessions prime API client before optimistic auth

### DIFF
--- a/ios-app/FareLens/App/AppState.swift
+++ b/ios-app/FareLens/App/AppState.swift
@@ -50,8 +50,10 @@ final class AppState {
         // Then validate auth in background without blocking UI
 
         // Phase 1: INSTANT - Load cached auth state (< 100ms)
-        if let cachedUser = await PersistenceService.shared.loadUser() {
-            // Optimistically show as authenticated
+        if let cachedUser = await PersistenceService.shared.loadUser(),
+           await AuthService.shared.primeSessionFromCache(using: cachedUser)
+        {
+            // Optimistically show as authenticated (API client already has JWT)
             currentUser = cachedUser
             isAuthenticated = true
             isLoading = false
@@ -63,6 +65,7 @@ final class AppState {
         } else {
             // No cached user - show onboarding immediately
             isAuthenticated = false
+            currentUser = nil
             isLoading = false
         }
 

--- a/ios-app/FareLens/Core/Services/AuthService.swift
+++ b/ios-app/FareLens/Core/Services/AuthService.swift
@@ -194,6 +194,23 @@ actor AuthService: AuthServiceProtocol {
         await tokenStore.loadTokens() != nil
     }
 
+    /// Preloads cached auth state so API requests include the JWT immediately after launch.
+    /// - Parameter user: The cached user that will be shown while validation runs in the background.
+    /// - Returns: `true` if cached tokens were restored and the API client primed; `false` if no tokens exist.
+    func primeSessionFromCache(using user: User) async -> Bool {
+        guard let tokens = await tokenStore.loadTokens() else {
+            logger.warning("Cached user found without corresponding auth tokens - clearing cached session")
+            currentUser = nil
+            await apiClient.setAuthToken(nil)
+            await persistenceService.clearUser()
+            return false
+        }
+
+        await apiClient.setAuthToken(tokens.accessToken)
+        currentUser = user
+        return true
+    }
+
     /// Get current authenticated user
     func getCurrentUser() async -> User? {
         // IMPORTANT: Always validate tokens before returning user to prevent


### PR DESCRIPTION
## Summary
- add an AuthService helper that primes the API client with cached tokens before showing an optimistic session
- gate AppState's cached-user path on the helper so we only show the authenticated UI once the Authorization header is ready
- clear stale cached users when tokens are missing to avoid replaying an invalid session

## Testing
- not run (iOS tooling unavailable in container)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690e6b3588e8832f8d671d5cd9220e77)