### PR TITLE
[iOS] Add save feedback to preferred airports screen

### DIFF
--- a/APPLE_QUALITY_MASTER_PLAN.md
+++ b/APPLE_QUALITY_MASTER_PLAN.md
@@ -1,0 +1,1244 @@
+# Apple Quality Master Plan
+## FareLens iOS App - Comprehensive Fix & Polish Strategy
+
+**Created**: 2025-11-27
+**Status**: Ready for Implementation
+**Estimated Total Time**: 60-80 hours
+**Priority**: All 10 PRs need polish to meet Apple HIG standards
+
+---
+
+## Executive Summary
+
+Our specialized agents (product-designer & code-reviewer) reviewed all 10 PRs and identified **93 total issues**:
+- **12 P0 Blocking Issues** (crashes, missing features, critical bugs)
+- **32 P1 High Priority Issues** (UX, accessibility, performance, maintainability)
+- **29 P2 Polish Issues** (microinter actions, animations, visual refinements)
+- **20 Testing Gaps** (missing unit tests, accessibility tests, edge case coverage)
+
+**Grade**: Current implementation is **B-** (Good, Not Great). Functional but lacks Apple-level polish.
+
+**Goal**: Achieve **A+** (Apple Quality) across all dimensions:
+- ✅ Functionality (already good)
+- ⚠️ Polish (needs significant work)
+- ⚠️ Accessibility (major gaps)
+- ⚠️ Micro-interactions (missing entirely)
+- ⚠️ Error Handling (needs improvement)
+- ⚠️ Performance (search needs optimization)
+
+---
+
+## Phase-by-Phase Implementation Plan
+
+### Phase 1: Fix P0 Blocking Issues (CRITICAL - Must Do First)
+**Time Estimate**: 8-12 hours
+**Priority**: BLOCKING
+**Description**: Fix production crashes, missing features, and critical bugs
+
+#### Tasks:
+
+**1.1 - Fix Division by Zero Crash in AlertsView** (#P0-CR-1)
+- **File**: `AlertsView.swift:160`
+- **Issue**: Progress ring crashes when `dailyLimit = 0`
+- **Fix**:
+```swift
+// Current (line 160):
+.trim(from: 0, to: CGFloat(sent) / CGFloat(limit))
+
+// Fixed:
+.trim(from: 0, to: limit > 0 ? CGFloat(sent) / CGFloat(limit) : 0)
+```
+- **Why**: Prevents crash for edge case users or during testing
+- **Time**: 15 minutes
+
+**1.2 - Implement Gear Icon Navigation** (#P0-CR-2)
+- **File**: `AlertsView.swift:66-72`
+- **Issue**: Gear icon button does nothing (just a comment)
+- **Fix**:
+```swift
+// Add @State variable:
+@State private var showingAlertPreferences = false
+
+// Update button:
+Button(action: {
+    showingAlertPreferences = true
+}) {
+    Image(systemName: "gear")
+        .foregroundColor(.brandBlue)
+}
+.accessibilityLabel("Alert settings")
+.sheet(isPresented: $showingAlertPreferences) {
+    AlertPreferencesView(viewModel: AlertPreferencesViewModel(user: viewModel.user))
+}
+```
+- **Why**: This was the entire point of PR #168
+- **Time**: 30 minutes
+
+**1.3 - Fix Search Algorithm Tier Count** (#P0-CR-3)
+- **File**: `Airport.swift` search function
+- **Issue**: PR title says "5-tier" but code implements 3-tier
+- **Fix**: Either add missing tiers (IATA prefix, city prefix) OR update PR title/comments
+- **Implementation**:
+```swift
+func search(query: String) -> [Airport] {
+    guard query.count >= 2 else { return [] }
+
+    let query = query.lowercased()
+    var results: [(airport: Airport, tier: Int)] = []
+
+    for airport in airports {
+        let iata = airport.iata.lowercased()
+        let name = airport.name.lowercased()
+        let city = airport.city.lowercased()
+
+        // Tier 1: Exact IATA match
+        if iata == query {
+            results.append((airport, 1))
+        }
+        // Tier 2: IATA prefix match
+        else if iata.hasPrefix(query) {
+            results.append((airport, 2))
+        }
+        // Tier 3: City prefix match
+        else if city.hasPrefix(query) {
+            results.append((airport, 3))
+        }
+        // Tier 4: Contains in name or city
+        else if name.contains(query) || city.contains(query) {
+            results.append((airport, 4))
+        }
+        // Tier 5: Fuzzy match (Levenshtein distance ≤ 2)
+        else if levenshteinDistance(city, query) <= 2 {
+            results.append((airport, 5))
+        }
+    }
+
+    // Sort by tier, then alphabetically
+    return results
+        .sorted { $0.tier == $1.tier ? $0.airport.city < $1.airport.city : $0.tier < $1.tier }
+        .map { $0.airport }
+        .prefix(10)
+        .map { $0 }
+}
+```
+- **Time**: 1 hour
+
+**1.4 - Fix Missing ErrorText Component** (#P0-CR-4)
+- **File**: Onboarding/OnboardingView.swift
+- **Issue**: References `ErrorText` component that doesn't exist
+- **Fix**: Either create the component OR inline the error text styling
+- **Quick Fix** (inline):
+```swift
+// Replace ErrorText(message: error.message) with:
+Text(error.message)
+    .footnoteStyle()
+    .foregroundColor(.error)
+    .padding(.horizontal, Spacing.xs)
+```
+- **Better Fix** (create reusable component):
+```swift
+// Create new file: DesignSystem/Components/ErrorText.swift
+struct ErrorText: View {
+    let message: String
+
+    var body: some View {
+        HStack(spacing: Spacing.xs) {
+            Image(systemName: "exclamationmark.triangle.fill")
+                .font(.caption)
+                .foregroundColor(.error)
+            Text(message)
+                .footnoteStyle()
+                .foregroundColor(.error)
+        }
+        .padding(.horizontal, Spacing.xs)
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("Error: \(message)")
+    }
+}
+```
+- **Time**: 45 minutes
+
+**1.5 - Replace String-Based Error Parsing** (#P0-CR-5)
+- **File**: `SettingsViewModel.swift:91-96`
+- **Issue**: Using `lowercased().contains()` for error matching is unsafe (locale bugs, internationalization issues)
+- **Fix**:
+```swift
+// Instead of string matching, use typed errors:
+catch let error as URLError {
+    switch error.code {
+    case .notConnectedToInternet, .networkConnectionLost, .timedOut:
+        errorMessage = "Network error. Please check your connection and try again."
+        feedbackGenerator.notificationOccurred(.error)
+    case .userAuthenticationRequired:
+        errorMessage = "Session expired. Please sign in again."
+        feedbackGenerator.notificationOccurred(.error)
+    default:
+        errorMessage = "Failed to save airports. Please try again."
+        feedbackGenerator.notificationOccurred(.error)
+    }
+} catch let error as AuthError {
+    errorMessage = "Session expired. Please sign in again."
+    feedbackGenerator.notificationOccurred(.error)
+} catch {
+    errorMessage = "Failed to save airports. Please try again."
+    feedbackGenerator.notificationOccurred(.error)
+}
+```
+- **Why**: Prevents displaying wrong error messages in non-English locales
+- **Time**: 1 hour
+
+**1.6 - Fix Untracked Background Task** (#P0-CR-6)
+- **File**: `SettingsViewModel.swift:85-88`
+- **Issue**: Detached Task can cause race conditions and incorrect UI state
+- **Fix**:
+```swift
+// Add property to SettingsViewModel:
+private var dismissSuccessTask: Task<Void, Never>?
+
+// In updatePreferredAirports():
+// Cancel any existing dismiss task
+dismissSuccessTask?.cancel()
+
+// Show success feedback
+showSaveSuccess = true
+
+// Haptic feedback (with optimized timing)
+Task { @MainActor in
+    try? await Task.sleep(for: .milliseconds(50))
+    feedbackGenerator.notificationOccurred(.success)
+}
+
+// Auto-hide success message after 1.2 seconds
+dismissSuccessTask = Task { @MainActor in
+    try? await Task.sleep(for: .seconds(1.2))
+    guard !Task.isCancelled else { return }
+    showSaveSuccess = false
+}
+
+// In deinit or when view disappears:
+deinit {
+    dismissSuccessTask?.cancel()
+}
+```
+- **Why**: Prevents race conditions when saving multiple times or navigating away
+- **Time**: 45 minutes
+
+**Phase 1 Total Time**: 4.5-6 hours
+
+---
+
+### Phase 2: Implement Progressive Disclosure for Free Tier
+**Time Estimate**: 6-8 hours
+**Priority**: P0 (UX critical)
+**Description**: Show locked features to Free users with clear upgrade path (Apple Settings app pattern)
+
+#### Tasks:
+
+**2.1 - Show Disabled Weight Controls with Lock Icon** (#P0-UX-1)
+- **Files**: `PreferredAirportsView.swift`, `AirportWeightRow`
+- **Current**: Weight controls completely hidden for Free users
+- **Fix**: Show disabled slider with lock icon and "Pro Feature" badge
+- **Implementation**:
+```swift
+// In AirportWeightRow:
+VStack(alignment: .leading, spacing: Spacing.xs) {
+    HStack {
+        Text("Weight: \(Int(weight * 100))%")
+            .footnoteStyle()
+            .foregroundColor(showWeightControls ? .textSecondary : .textTertiary)
+
+        if !showWeightControls {
+            Image(systemName: "lock.fill")
+                .font(.caption2)
+                .foregroundColor(.brandBlue)
+
+            Text("Pro")
+                .caption2Style()
+                .foregroundColor(.white)
+                .padding(.horizontal, Spacing.xs)
+                .padding(.vertical, 2)
+                .background(Color.brandBlue)
+                .cornerRadius(4)
+        }
+    }
+}
+
+// Slider with disabled state
+VStack(spacing: Spacing.xs) {
+    Slider(value: .constant(weight), in: 0.0...1.0)
+        .disabled(!showWeightControls)
+        .opacity(showWeightControls ? 1.0 : 0.5)
+        .tint(showWeightControls ? .brandBlue : .textTertiary)
+        .onTapGesture {
+            if !showWeightControls {
+                // Trigger upgrade sheet
+                onUpgradeRequired?()
+            }
+        }
+
+    HStack {
+        Text("0%").captionStyle()
+        Spacer()
+        Text("100%").captionStyle()
+    }
+    .foregroundColor(showWeightControls ? .textSecondary : .textTertiary)
+}
+.accessibilityHint(showWeightControls ? "" : "Pro feature. Double tap to learn more.")
+```
+- **Time**: 2 hours
+
+**2.2 - Add Pro Badge and Upgrade Sheet Trigger** (#P0-UX-2)
+- **Files**: `PreferredAirportsView.swift`
+- **Fix**: Add onUpgradeRequired callback to AirportWeightRow
+- **Implementation**:
+```swift
+// Update AirportWeightRow signature:
+struct AirportWeightRow: View {
+    let airport: PreferredAirport
+    let weight: Double
+    let showWeightControls: Bool
+    let onWeightChange: ((Double) -> Void)?
+    let onDelete: () -> Void
+    let onUpgradeRequired: (() -> Void)?  // NEW
+
+    // ... rest of implementation
+}
+
+// In PreferredAirportsView, pass upgrade callback:
+AirportWeightRow(
+    airport: airport,
+    weight: airport.weight,
+    showWeightControls: viewModel.user.subscriptionTier == .pro,
+    onWeightChange: viewModel.user.subscriptionTier == .pro ? { newWeight in
+        viewModel.updateAirportWeight(at: index, weight: newWeight)
+    } : nil,
+    onDelete: {
+        viewModel.removePreferredAirport(at: index)
+    },
+    onUpgradeRequired: {
+        viewModel.showingUpgradeSheet = true
+    }
+)
+```
+- **Time**: 1.5 hours
+
+**2.3 - Show Total Weight Section for Free Users** (#P0-UX-3)
+- **Files**: `PreferredAirportsView.swift:37-54`
+- **Current**: Total Weight section completely hidden for Free users
+- **Fix**: Show with educational message
+- **Implementation**:
+```swift
+// Always show Total Weight section
+Section {
+    HStack {
+        Text("Total Weight")
+            .bodyStyle()
+        Spacer()
+        Text(String(format: "%.1f", viewModel.preferredAirports.totalWeight))
+            .headlineStyle()
+            .foregroundColor(viewModel.isWeightSumValid ? .success : .error)
+    }
+} footer: {
+    if viewModel.user.subscriptionTier == .pro {
+        if !viewModel.isWeightSumValid {
+            Text("Weights must sum to 1.0")
+                .footnoteStyle()
+                .foregroundColor(.error)
+        }
+    } else {
+        // Educational message for Free users
+        HStack(spacing: Spacing.xs) {
+            Image(systemName: "info.circle.fill")
+                .font(.caption)
+                .foregroundColor(.brandBlue)
+            Text("Pro users can prioritize multiple airports with custom weights (e.g., 60% LAX, 40% SFO)")
+                .footnoteStyle()
+                .foregroundColor(.textSecondary)
+        }
+        .padding(.vertical, Spacing.xs)
+    }
+}
+```
+- **Time**: 1 hour
+
+**Phase 2 Total Time**: 4.5-6 hours
+
+---
+
+### Phase 3: Add State Transition Animations
+**Time Estimate**: 4-6 hours
+**Priority**: P0 (UX critical)
+**Description**: Add Apple-quality spring animations to all state changes
+
+#### Tasks:
+
+**3.1 - Add Spring Animations to Save Button** (#P0-UX-6)
+- **File**: `PreferredAirportsView.swift:71-108`
+- **Current**: Button morphs instantly between states (jarring)
+- **Fix**:
+```swift
+Group {
+    // ... button states
+}
+.animation(.spring(response: 0.3, dampingFraction: 0.7), value: viewModel.isSaving)
+.animation(.spring(response: 0.3, dampingFraction: 0.7), value: viewModel.showSaveSuccess)
+.transition(.scale.combined(with: .opacity))
+```
+- **Time**: 30 minutes
+
+**3.2 - Add Empty State Transitions** (#P2-UX-2)
+- **Files**: All empty state views
+- **Fix**:
+```swift
+EmptyAlertsView(...)
+    .transition(.opacity.combined(with: .scale(scale: 0.95)))
+    .animation(.spring(response: 0.4, dampingFraction: 0.8), value: viewModel.filteredAlerts.isEmpty)
+```
+- **Time**: 1 hour
+
+**3.3 - Add Checkmark Drawing Animation** (#P2-UX-6)
+- **File**: `PreferredAirportsView.swift:88`
+- **Fix**:
+```swift
+Image(systemName: "checkmark.circle.fill")
+    .foregroundColor(.white)
+    .font(.title3)
+    .transition(.scale.combined(with: .opacity))
+    .animation(.spring(response: 0.3, dampingFraction: 0.6), value: viewModel.showSaveSuccess)
+```
+- **Time**: 30 minutes
+
+**Phase 3 Total Time**: 2-3 hours
+
+---
+
+### Phase 4: Implement Comprehensive Haptic Feedback
+**Time Estimate**: 3-4 hours
+**Priority**: P1 (High)
+**Description**: Add tactile feedback for all user actions (Apple standard)
+
+#### Tasks:
+
+**4.1 - Add Prepared Haptic Generator** (#P1-CR-3)
+- **File**: `SettingsViewModel.swift`
+- **Fix**:
+```swift
+// Add property:
+private let feedbackGenerator = UINotificationFeedbackGenerator()
+
+// In init:
+init(user: User) {
+    self.user = user
+    alertPreferences = user.alertPreferences
+    preferredAirports = user.preferredAirports
+    feedbackGenerator.prepare()
+}
+
+// Before save:
+func updatePreferredAirports() async {
+    feedbackGenerator.prepare()  // Re-prepare before use
+
+    // ... save logic
+
+    // On success:
+    feedbackGenerator.notificationOccurred(.success)
+
+    // On error:
+    feedbackGenerator.notificationOccurred(.error)
+}
+```
+- **Time**: 45 minutes
+
+**4.2 - Add Slider Haptic Feedback** (#P1-UX-2)
+- **File**: `PreferredAirportsView.swift` (AirportWeightRow)
+- **Fix**:
+```swift
+Slider(value: Binding(
+    get: { weight },
+    set: { newValue in
+        onWeightChange(newValue)
+        // Add light haptic on value change
+        UIImpactFeedbackGenerator(style: .light).impactOccurred()
+    }
+), in: 0.0...1.0, step: 0.05)  // Changed to 5% increments
+```
+- **Time**: 30 minutes
+
+**4.3 - Optimize Haptic Timing** (#P1-UX-11)
+- **File**: `SettingsViewModel.swift:80-82`
+- **Current**: Haptic fires immediately, feels disconnected
+- **Fix**: Delay haptic by 50ms to coincide with visual update
+```swift
+showSaveSuccess = true
+
+Task { @MainActor in
+    try? await Task.sleep(for: .milliseconds(50))
+    feedbackGenerator.notificationOccurred(.success)
+}
+```
+- **Time**: 15 minutes
+
+**Phase 4 Total Time**: 1.5-2 hours
+
+---
+
+### Phase 5: Add Complete Accessibility Support
+**Time Estimate**: 8-12 hours
+**Priority**: P1 (High - Legal requirement under ADA)
+**Description**: Make app fully usable with VoiceOver and accessibility features
+
+#### Tasks:
+
+**5.1 - Add VoiceOver Labels to All Interactive Elements** (#P1-CR-7)
+- **Files**: All view files
+- **Scope**: ~50+ interactive elements need labels
+- **Examples**:
+```swift
+// Delete button (PreferredAirportsView.swift:175)
+Button(action: onDelete) {
+    Image(systemName: "trash")
+}
+.accessibilityLabel("Delete \(airport.iata) from preferred airports")
+.accessibilityHint("Double tap to remove")
+
+// Add airport button (PreferredAirportsView.swift:119)
+Button(action: { ... }) {
+    Image(systemName: "plus")
+}
+.accessibilityLabel("Add preferred airport")
+.accessibilityHint("Double tap to add a new airport")
+
+// Gear icon (AlertsView.swift:69)
+Button(action: { ... }) {
+    Image(systemName: "gear")
+}
+.accessibilityLabel("Alert settings")
+.accessibilityHint("Double tap to configure alert preferences")
+
+// Weight slider (AirportWeightRow)
+Slider(...)
+    .accessibilityLabel("Weight for \(airport.iata)")
+    .accessibilityValue("\(Int(weight * 100)) percent")
+
+// Progress ring (AlertsView.swift:154-168)
+ZStack {
+    // progress ring
+}
+.accessibilityElement(children: .ignore)
+.accessibilityLabel("Alerts sent today")
+.accessibilityValue("\(sent) of \(limit) sent")
+```
+- **Time**: 4-6 hours
+
+**5.2 - Add Accessibility Hints for Pro-Locked Features** (#P1-UX-1)
+- **Files**: All Pro-gated features
+- **Fix**:
+```swift
+Slider(...)
+    .disabled(!showWeightControls)
+    .accessibilityHint(showWeightControls ?
+        "Swipe up or down to adjust weight" :
+        "Pro feature. Double tap to learn about upgrading")
+```
+- **Time**: 1 hour
+
+**5.3 - Add VoiceOver Announcements for State Changes**
+- **Files**: SettingsViewModel, AlertsViewModel
+- **Fix**:
+```swift
+// After successful save:
+showSaveSuccess = true
+UIAccessibility.post(notification: .announcement, argument: "Airports saved successfully")
+
+// After error:
+errorMessage = "Failed to save"
+UIAccessibility.post(notification: .announcement, argument: "Error: Failed to save airports")
+```
+- **Time**: 1 hour
+
+**5.4 - Test with Dynamic Type**
+- **Task**: Open app with Accessibility XXL text size, verify all layouts work
+- **Time**: 1 hour
+
+**5.5 - Test with VoiceOver**
+- **Task**: Navigate entire app with VoiceOver, verify all actions work
+- **Time**: 2 hours
+
+**Phase 5 Total Time**: 9-11 hours
+
+---
+
+### Phase 6: Enhance Form Validation UX
+**Time Estimate**: 4-6 hours
+**Priority**: P1 (High)
+**Description**: Make validation clear, helpful, and guide users to success
+
+#### Tasks:
+
+**6.1 - Add Inline Validation with Helpful Guidance** (#P1-UX-4)
+- **File**: `PreferredAirportsView.swift:42-44`
+- **Current**: Shows "Weights must sum to 1.0" when invalid
+- **Fix**: Show current total and how much to adjust
+```swift
+Section {
+    HStack {
+        Text("Total Weight")
+            .bodyStyle()
+        Spacer()
+        Text(String(format: "%.1f", viewModel.preferredAirports.totalWeight))
+            .headlineStyle()
+            .foregroundColor(viewModel.isWeightSumValid ? .success : .error)
+    }
+} footer: {
+    if !viewModel.isWeightSumValid {
+        let total = viewModel.preferredAirports.totalWeight
+        let diff = abs(1.0 - total)
+        let adjustment = total < 1.0 ? "add \(String(format: "%.1f", diff))" : "reduce by \(String(format: "%.1f", diff))"
+
+        HStack(spacing: Spacing.xs) {
+            Image(systemName: "exclamationmark.triangle.fill")
+                .font(.caption)
+                .foregroundColor(.error)
+            Text("Weights must sum to 1.0 (currently \(String(format: "%.1f", total)), \(adjustment))")
+                .footnoteStyle()
+                .foregroundColor(.error)
+        }
+    }
+}
+```
+- **Time**: 1 hour
+
+**6.2 - Add Swipe-to-Delete Confirmation** (#P1-UX-5)
+- **File**: `PreferredAirportsView.swift:175-179`
+- **Current**: Trash button has no confirmation
+- **Fix**: Use swipeActions with confirmation alert
+```swift
+// Remove trash button, add swipe action:
+.swipeActions(edge: .trailing, allowsFullSwipe: true) {
+    Button(role: .destructive) {
+        // Show confirmation alert
+        showDeleteConfirmation = (true, index)
+    } label: {
+        Label("Delete", systemImage: "trash")
+    }
+}
+.alert("Remove \(airport.iata)?", isPresented: $showDeleteConfirmation) {
+    Button("Cancel", role: .cancel) { }
+    Button("Remove", role: .destructive) {
+        viewModel.removePreferredAirport(at: confirmationIndex)
+    }
+} message: {
+    Text("This airport will be removed from your preferred list.")
+}
+```
+- **Time**: 1.5 hours
+
+**6.3 - Add Error Recovery Buttons** (#P1-UX-13)
+- **File**: `PreferredAirportsView.swift:65-69`
+- **Current**: Error message shown as text only
+- **Fix**: Add retry button
+```swift
+if let error = viewModel.errorMessage {
+    VStack(spacing: Spacing.xs) {
+        HStack(spacing: Spacing.xs) {
+            Image(systemName: "exclamationmark.triangle.fill")
+                .font(.caption)
+                .foregroundColor(.error)
+            Text(error)
+                .footnoteStyle()
+                .foregroundColor(.error)
+        }
+
+        Button("Try Again") {
+            Task {
+                await viewModel.updatePreferredAirports()
+            }
+        }
+        .font(.footnote)
+        .foregroundColor(.brandBlue)
+    }
+    .padding(Spacing.sm)
+    .background(Color.error.opacity(0.1))
+    .cornerRadius(CornerRadius.sm)
+}
+```
+- **Time**: 45 minutes
+
+**6.4 - Add Visual Feedback for Disabled Save Button** (#P1-UX-15)
+- **File**: `PreferredAirportsView.swift:106`
+- **Current**: Disabled button looks same as enabled
+- **Fix**:
+```swift
+FLButton(title: "Save Changes", style: .primary) {
+    Task {
+        await viewModel.updatePreferredAirports()
+    }
+}
+.disabled(!viewModel.isWeightSumValid)
+.opacity(viewModel.isWeightSumValid ? 1.0 : 0.5)
+.animation(.easeInOut(duration: 0.2), value: viewModel.isWeightSumValid)
+```
+- **Time**: 15 minutes
+
+**Phase 6 Total Time**: 3.5-4.5 hours
+
+---
+
+### Phase 7: Optimize Search Experience
+**Time Estimate**: 4-6 hours
+**Priority**: P1 (High)
+**Description**: Make search fast, efficient, and provide great results
+
+#### Tasks:
+
+**7.1 - Add Search Debouncing and Task Cancellation** (#P1-CR-5)
+- **File**: `PreferredAirportsView.swift:268-270`
+- **Current**: Every keystroke triggers search (10x more API calls than needed)
+- **Fix**:
+```swift
+// Add to AddAirportSheet:
+@State private var searchTask: Task<Void, Never>?
+
+.onChange(of: searchQuery) { _, newValue in
+    // Cancel previous search
+    searchTask?.cancel()
+
+    // Debounce: only search after 300ms of no typing
+    searchTask = Task {
+        try? await Task.sleep(for: .milliseconds(300))
+        guard !Task.isCancelled else { return }
+        await performSearch(newValue)
+    }
+}
+
+private func performSearch(_ query: String) async {
+    guard !Task.isCancelled else { return }
+    guard query.count >= 2 else {
+        searchResults = []
+        isSearching = false
+        return
+    }
+
+    isSearching = true
+
+    guard !Task.isCancelled else {
+        isSearching = false
+        return
+    }
+
+    searchResults = await AirportService.shared.search(query: query)
+    isSearching = false
+}
+```
+- **Time**: 1.5 hours
+
+**7.2 - Add Minimum Query Length** (#Nit-1)
+- **Already included in 7.1**
+
+**7.3 - Add Result Highlighting**
+- **File**: `PreferredAirportsView.swift` (AddAirportSheet result row)
+- **Fix**: Highlight matching text in search results
+```swift
+// In ForEach(searchResults):
+VStack(alignment: .leading, spacing: Spacing.xs) {
+    Text(airport.iata)
+        .headlineStyle()
+        .foregroundColor(.textPrimary)
+        // Add highlighting by making matching characters bold
+
+    Text(highlightedText(airport.cityDisplay, query: searchQuery))
+        .bodyStyle()
+        .foregroundColor(.textSecondary)
+}
+
+private func highlightedText(_ text: String, query: String) -> AttributedString {
+    var attributed = AttributedString(text)
+    if let range = text.range(of: query, options: .caseInsensitive) {
+        let attributedRange = AttributedString.Index(range.lowerBound, within: attributed)!..<AttributedString.Index(range.upperBound, within: attributed)!
+        attributed[attributedRange].font = .headline
+        attributed[attributedRange].foregroundColor = .brandBlue
+    }
+    return attributed
+}
+```
+- **Time**: 2 hours
+
+**7.4 - Optimize Search Algorithm Performance**
+- **File**: `Airport.swift` search function
+- **Current**: O(4n) - iterates through array 4 times
+- **Fix**: O(n) - single pass with tier assignment
+```swift
+func search(query: String) -> [Airport] {
+    guard query.count >= 2 else { return [] }
+
+    let query = query.lowercased()
+    var results: [(airport: Airport, tier: Int)] = []
+
+    // Single pass through airports
+    for airport in airports {
+        let iata = airport.iata.lowercased()
+        let name = airport.name.lowercased()
+        let city = airport.city.lowercased()
+
+        // Assign tier based on first match (tiers are mutually exclusive)
+        let tier: Int? = {
+            if iata == query { return 1 }
+            if iata.hasPrefix(query) { return 2 }
+            if city.hasPrefix(query) { return 3 }
+            if name.contains(query) || city.contains(query) { return 4 }
+            if levenshteinDistance(city, query) <= 2 { return 5 }
+            return nil
+        }()
+
+        if let tier = tier {
+            results.append((airport, tier))
+        }
+    }
+
+    // Sort by tier, then alphabetically
+    return results
+        .sorted { $0.tier == $1.tier ? $0.airport.city < $1.airport.city : $0.tier < $1.tier }
+        .prefix(10)
+        .map { $0.airport }
+}
+```
+- **Time**: 1 hour
+
+**Phase 7 Total Time**: 4.5-6 hours
+
+---
+
+### Phase 8: Improve Empty States
+**Time Estimate**: 4-6 hours
+**Priority**: P1 (High)
+**Description**: Make empty states helpful, actionable, and educational
+
+#### Tasks:
+
+**8.1 - Fix Deals Empty State Logic** (#P0-UX-deals)
+- **File**: `DealsView.swift`
+- **Issue**: "Create Watchlist" CTA doesn't make sense when no deals found
+- **Fix**: Show context-aware CTA
+```swift
+// Check if user has preferred airports
+if viewModel.user.preferredAirports.isEmpty {
+    // No preferred airports set
+    EmptyDealsView(
+        title: "Set Your Home Airport",
+        message: "Add your preferred airport to start seeing personalized flight deals",
+        buttonTitle: "Set Preferred Airport",
+        action: {
+            // Navigate to airport settings
+        }
+    )
+} else if viewModel.deals.isEmpty {
+    // Has airports but no deals
+    EmptyDealsView(
+        title: "No deals right now",
+        message: "We're actively monitoring flights from your preferred airports. Check back soon!",
+        buttonTitle: "Create Watchlist",
+        secondaryButtonTitle: "Adjust Preferences",
+        action: {
+            // Navigate to watchlist creation
+        },
+        secondaryAction: {
+            // Navigate to settings
+        }
+    )
+}
+```
+- **Time**: 2 hours
+
+**8.2 - Add Actionable CTAs to Empty States** (#P1-UX-7)
+- **Files**: AlertsView, DealsView
+- **Fix**: Make CTAs specific and actionable
+- **Time**: 1 hour
+
+**8.3 - Add Onboarding Checklist to Alerts Empty State** (#P1-UX-8)
+- **File**: `AlertsView.swift` (EmptyAlertsView)
+- **Fix**:
+```swift
+VStack(spacing: Spacing.lg) {
+    Image(systemName: "bell.slash")
+        .font(.system(size: 64))
+        .foregroundColor(.brandBlue.opacity(0.5))
+
+    VStack(spacing: Spacing.sm) {
+        Text("No alerts yet")
+            .title2Style()
+
+        Text("Complete setup to start receiving deals:")
+            .bodyStyle()
+            .foregroundColor(.textSecondary)
+    }
+
+    // Checklist
+    VStack(alignment: .leading, spacing: Spacing.sm) {
+        ChecklistItem(
+            icon: viewModel.user.preferredAirports.isEmpty ? "circle" : "checkmark.circle.fill",
+            text: "Set preferred airports",
+            isComplete: !viewModel.user.preferredAirports.isEmpty,
+            action: {
+                // Navigate to airport settings
+            }
+        )
+
+        ChecklistItem(
+            icon: viewModel.user.watchlists.isEmpty ? "circle" : "checkmark.circle.fill",
+            text: "Create a watchlist (optional)",
+            isComplete: !viewModel.user.watchlists.isEmpty,
+            action: {
+                // Navigate to watchlist creation
+            }
+        )
+
+        ChecklistItem(
+            icon: "circle",
+            text: "Receive your first alert",
+            isComplete: false,
+            action: nil
+        )
+    }
+    .padding(Spacing.md)
+    .background(Color.cardBackground)
+    .cornerRadius(CornerRadius.md)
+}
+```
+- **Time**: 2 hours
+
+**8.4 - Improve InfoBox Visual Hierarchy** (#P2-UX-3)
+- **File**: InfoBox component
+- **Fix**: Use bullet points, better spacing
+- **Time**: 30 minutes
+
+**8.5 - Add Pull-to-Refresh to Empty States** (#P2-UX-5)
+- **Files**: AlertsView, DealsView
+- **Fix**: Add `.refreshable()` modifier to empty states
+- **Time**: 30 minutes
+
+**Phase 8 Total Time**: 6-8 hours
+
+---
+
+### Phase 9: Enhance Micro-interactions
+**Time Estimate**: 3-5 hours
+**Priority**: P1 (High)
+**Description**: Add delightful details that make the app feel polished
+
+#### Tasks:
+
+**9.1 - Add Button Press Scale Animation**
+- **Files**: All button components
+- **Fix**:
+```swift
+// In FLButton component:
+Button(action: action) {
+    // ... button content
+}
+.scaleEffect(isPressed ? 0.96 : 1.0)
+.animation(.easeInOut(duration: 0.1), value: isPressed)
+.simultaneousGesture(
+    DragGesture(minimumDistance: 0)
+        .onChanged { _ in isPressed = true }
+        .onEnded { _ in isPressed = false }
+)
+```
+- **Time**: 1.5 hours
+
+**9.2 - Reduce Success Auto-Dismiss Time** (#P1-UX-12)
+- **File**: `SettingsViewModel.swift:86`
+- **Current**: 2 seconds feels slow
+- **Fix**: Change to 1.2 seconds (already in plan for Phase 1.6)
+- **Time**: 5 minutes
+
+**9.3 - Implement Optimistic UI** (#P1-UX-14)
+- **File**: `SettingsViewModel.swift` updatePreferredAirports
+- **Fix**:
+```swift
+func updatePreferredAirports() async {
+    guard isWeightSumValid else {
+        errorMessage = "Airport weights must sum to 1.0"
+        return
+    }
+
+    // Optimistic update - update UI immediately
+    let previousAirports = user.preferredAirports
+    user.preferredAirports = preferredAirports
+
+    isSaving = true
+    errorMessage = nil
+    defer { isSaving = false }
+
+    do {
+        let endpoint = APIEndpoint.updateUser(preferredAirports: preferredAirports)
+        try await APIClient.shared.requestNoResponse(endpoint)
+
+        // Success - show feedback
+        showSaveSuccess = true
+        feedbackGenerator.notificationOccurred(.success)
+
+        // Auto-hide
+        dismissSuccessTask?.cancel()
+        dismissSuccessTask = Task { @MainActor in
+            try? await Task.sleep(for: .seconds(1.2))
+            guard !Task.isCancelled else { return }
+            showSaveSuccess = false
+        }
+    } catch {
+        // Revert optimistic update on error
+        user.preferredAirports = previousAirports
+        preferredAirports = previousAirports
+
+        // Handle error...
+        feedbackGenerator.notificationOccurred(.error)
+    }
+}
+```
+- **Time**: 1 hour
+
+**9.4 - Add Reduce Motion Support**
+- **Files**: All animated views
+- **Fix**:
+```swift
+@Environment(\.accessibilityReduceMotion) var reduceMotion
+
+// In animations:
+.animation(reduceMotion ? nil : .spring(...), value: ...)
+```
+- **Time**: 1 hour
+
+**Phase 9 Total Time**: 3.5-5 hours
+
+---
+
+### Phase 10: Code Quality Improvements
+**Time Estimate**: 3-4 hours
+**Priority**: P1 (Maintainability)
+**Description**: Clean up code duplication, use modern APIs, fix patterns
+
+#### Tasks:
+
+**10.1 - Replace Duplicate Tier Checks** (#P1-CR-6)
+- **Files**: PreferredAirportsView.swift (lines 22, 37)
+- **Fix**: Use existing `user.isProUser` property
+```swift
+// Replace all instances of:
+viewModel.user.subscriptionTier == .pro
+
+// With:
+viewModel.user.isProUser
+```
+- **Time**: 15 minutes
+
+**10.2 - Make onWeightChange Optional** (#P1-CR-4)
+- **File**: `PreferredAirportsView.swift:23-24`
+- **Fix**: Only pass callback for Pro users (already covered in Phase 2)
+- **Time**: Included in Phase 2
+
+**10.3 - Replace errorMessage with assertionFailure** (#P1-CR-8)
+- **Files**: SettingsViewModel.swift lines 115, 124
+- **Fix**:
+```swift
+func removePreferredAirport(at index: Int) {
+    guard index >= 0, index < preferredAirports.count else {
+        assertionFailure("Invalid airport index: \(index), count: \(preferredAirports.count)")
+        return
+    }
+    preferredAirports.remove(at: index)
+}
+
+func updateAirportWeight(at index: Int, weight: Double) {
+    guard index >= 0, index < preferredAirports.count else {
+        assertionFailure("Invalid airport index: \(index), count: \(preferredAirports.count)")
+        return
+    }
+    preferredAirports[index].weight = weight
+}
+```
+- **Time**: 15 minutes
+
+**10.4 - Use Modern Task.sleep API** (#Nit-2)
+- **Files**: All files using Task.sleep
+- **Fix**: Replace `nanoseconds: 2_000_000_000` with `for: .seconds(2)`
+- **Time**: 30 minutes
+
+**10.5 - Add Floating Point Tolerance for Weight Validation** (#edge-case)
+- **File**: PreferredAirport model or validation
+- **Fix**:
+```swift
+extension [PreferredAirport] {
+    var isValidWeightSum: Bool {
+        let total = reduce(0.0) { $0 + $1.weight }
+        return abs(total - 1.0) < 0.01  // 1% tolerance
+    }
+}
+```
+- **Time**: 15 minutes
+
+**Phase 10 Total Time**: 1.5-2 hours
+
+---
+
+### Phase 11: Fix Gemini-Identified Issues
+**Time Estimate**: 2-3 hours
+**Priority**: P1
+**Description**: Address specific issues raised by Gemini Code Assist
+
+#### Tasks:
+
+**11.1 - Fix UUID Handling for Preferred Airports**
+- **File**: Backend PATCH /user endpoint
+- **Issue**: Gemini noted "critical issue with how preferred airport UUIDs are handled"
+- **Investigation**: Need to read backend code to see the specific issue
+- **Time**: 1.5 hours
+
+**11.2 - Verify Tier-Based Validations**
+- **Files**: Backend validation logic
+- **Task**: Test that Free tier (1 airport) and Pro tier (3 airports) limits work correctly
+- **Time**: 1 hour
+
+**Phase 11 Total Time**: 2.5-3.5 hours
+
+---
+
+### Phase 12: Testing & Verification
+**Time Estimate**: 8-12 hours
+**Priority**: CRITICAL
+**Description**: Comprehensive testing to ensure everything works
+
+#### Tasks:
+
+**12.1 - Run Swift Test Suite**
+- **Command**: `swift test`
+- **Fix any failures**
+- **Time**: 2 hours
+
+**12.2 - Test on Device - Free Tier Account**
+- **Scope**: Test all 10 PRs with Free tier account
+- **Verify**: Weight controls locked, upgrade prompts, 1 airport limit
+- **Time**: 2 hours
+
+**12.3 - Test on Device - Pro Tier Account**
+- **Scope**: Test all 10 PRs with Pro tier account
+- **Verify**: Weight controls work, 3 airport limit, watchlist-only mode
+- **Time**: 2 hours
+
+**12.4 - Test with Network Link Conditioner**
+- **Scenarios**: Slow 3G, 100% packet loss, high latency
+- **Verify**: Loading states, error handling, retry logic
+- **Time**: 1 hour
+
+**12.5 - Run Xcode Accessibility Inspector**
+- **Check**: All labels, hints, contrast ratios
+- **Fix any violations**
+- **Time**: 1.5 hours
+
+**12.6 - Test Weight Validation Edge Cases**
+- **Cases**: 0.999, 1.001, 0.0, 2.0, negative values
+- **Verify**: Tolerance works, validation messages clear
+- **Time**: 30 minutes
+
+**12.7 - Test All Empty States**
+- **Verify**: Correct messages, working CTAs, proper navigation
+- **Time**: 1 hour
+
+**12.8 - Test All Animations**
+- **Verify**: Smooth transitions, no jank, Reduce Motion support
+- **Time**: 1 hour
+
+**Phase 12 Total Time**: 11-14 hours
+
+---
+
+## Total Time Estimates
+
+| Phase | Description | Time Estimate |
+|-------|-------------|---------------|
+| 1 | P0 Blocking Issues | 8-12 hours |
+| 2 | Progressive Disclosure | 6-8 hours |
+| 3 | State Animations | 4-6 hours |
+| 4 | Haptic Feedback | 3-4 hours |
+| 5 | Accessibility | 8-12 hours |
+| 6 | Form Validation | 4-6 hours |
+| 7 | Search Optimization | 4-6 hours |
+| 8 | Empty States | 4-6 hours |
+| 9 | Micro-interactions | 3-5 hours |
+| 10 | Code Quality | 3-4 hours |
+| 11 | Gemini Issues | 2-3 hours |
+| 12 | Testing | 8-12 hours |
+| **TOTAL** | **All Phases** | **57-84 hours** |
+
+**Realistic Estimate**: 60-70 hours for full Apple-quality implementation
+
+---
+
+## Priority Tiers for Implementation
+
+### MUST DO (Blocking - 20-28 hours)
+- Phase 1: P0 Blocking Issues (8-12h)
+- Phase 2: Progressive Disclosure (6-8h)
+- Phase 3: State Animations (4-6h)
+- Phase 12: Testing (2h basics)
+
+### SHOULD DO (Critical UX - 22-30 hours)
+- Phase 4: Haptic Feedback (3-4h)
+- Phase 5: Accessibility (8-12h)
+- Phase 6: Form Validation (4-6h)
+- Phase 7: Search Optimization (4-6h)
+- Phase 8: Empty States (4-6h)
+
+### NICE TO HAVE (Polish - 15-24 hours)
+- Phase 9: Micro-interactions (3-5h)
+- Phase 10: Code Quality (3-4h)
+- Phase 11: Gemini Issues (2-3h)
+- Phase 12: Full Testing (8-12h)
+
+---
+
+## Questions for User
+
+Before starting implementation, I need clarification on:
+
+1. **Scope**: Do you want me to implement ALL phases (60-70 hours), or prioritize certain phases?
+
+2. **Backend Access**: Can I modify backend code (Cloudflare Workers) for Phase 11 (Gemini UUID issue)?
+
+3. **Testing**: Do you have test accounts for Free and Pro tiers, or should I create test users?
+
+4. **Deployment**: Should I create separate PRs for each phase, or combine related phases?
+
+5. **ErrorText Component**: Should I create a reusable component or inline the styling? (Phase 1.4)
+
+6. **Priority**: Are there specific features/screens that are higher priority? (e.g., onboarding more critical than settings?)
+
+7. **Design System**: Should I create reusable components for patterns like ChecklistItem, or inline implementations?
+
+---
+
+## Success Criteria
+
+We'll know we've achieved Apple quality when:
+
+✅ **Functionality**: All 10 PRs work correctly with no crashes or bugs
+✅ **Polish**: Smooth animations, delightful haptics, no jarring transitions
+✅ **Accessibility**: Full VoiceOver support, WCAG AAA compliance
+✅ **Performance**: Search is instant (<100ms), no lag or jank
+✅ **Progressive Disclosure**: Free users understand Pro features and how to unlock them
+✅ **Error Handling**: Clear, actionable error messages with recovery options
+✅ **Empty States**: Helpful, educational, with clear next steps
+✅ **Testing**: 100% pass rate on all tests, works on Free + Pro tiers
+
+**Target Grade**: A+ (Apple Quality Standard)
+
+---
+
+## Next Steps
+
+1. **User reviews this plan and answers questions**
+2. **User approves scope and priority**
+3. **I begin Phase 1 implementation**
+4. **We iterate through phases sequentially**
+5. **We test thoroughly after each phase**
+6. **We ship polished, Apple-quality code**
+
+Ready to start when you are! 🚀

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,7 +15,7 @@
 3. Use ios-architect to create ARCHITECTURE.md (may challenge design feasibility)
 4. Use backend-architect to create API.md (if backend needed)
 5. Implement following architecture docs
-6. Use code-reviewer before every commit (blocks on P0 issues)
+6. Use code-reviewer before every commit (blocks on P0/P1 issues)
 7. Use qa-specialist to create TEST_PLAN.md
 8. Use platform-engineer when ready to deploy
 
@@ -46,7 +46,8 @@ TEST_PLAN.md - Testing strategy (qa-specialist)
 ## Workflow
 
 - Run tests before committing (no exceptions)
-- Code-reviewer must approve before merge (zero P0 issues)
+- Code-reviewer must approve before merge (zero P0, P1, P2 issues)
+- product-manager and product-designer must align with all changes impacting the customer experience in any way
 - Subagents make technical decisions autonomously
 - User decides: brand identity, business priorities, product trade-offs
 - On conflicts between agents: Stop, present options, let user decide
@@ -55,13 +56,13 @@ TEST_PLAN.md - Testing strategy (qa-specialist)
 
 Can merge:
 - All tests pass
-- Code-reviewer approved
-- Coverage ≥80% (≥95% for critical paths)
+- Code-reviewer, product-manager, product-designer, ios-architect, and backend-architect approved
+- Coverage ≥90% (≥95% for critical paths)
 
 Can ship:
 - Crash-free ≥99.5%
 - Launch <2s on iPhone SE
-- No P0 bugs
+- No P0/P1 bugs
 
 ## Project Structure
 
@@ -75,7 +76,7 @@ ios-app/
 
 ## Common Patterns
 
-Adding a feature:
+Adding/updating a feature or adding missing details to a feature or app experience:
 1. product-manager adds to PRD.md
 2. product-designer designs UI in DESIGN.md
 3. ios-architect plans implementation
@@ -84,14 +85,15 @@ Adding a feature:
 
 Fixing a bug:
 1. Write failing test
-2. Fix bug
-3. code-reviewer reviews fix
-4. Verify test passes
+2. product-manager or product-designer provides feedback on fix.
+3. Fix bug
+4. code-reviewer reviews fix
+5. Verify test passes
 
 ## Design References
 
 - Competitor UX screenshots in design-refs/competitors/
-- product-designer should review these before creating DESIGN.md
+- product-designer and product-manager should review these before creating DESIGN.md and during the project when neccessary.
 
 ## Project-Specific Notes
 
@@ -111,17 +113,17 @@ Fixing a bug:
 
 ### Error Prevention Protocol
 **BEFORE making changes:**
-1. Read the ENTIRE section you're modifying (not just the line)
+1. Read the ENTIRE section you're modifying (not just the line) and consider other files or sections that may need modification
 2. Use Grep to find ALL instances of what you're changing (e.g., all pricing, all Redis refs)
 3. Make a checklist of every location that needs updating
 4. Update systematically, checking off each location
 5. AFTER changes: Grep again to verify NO old references remain
 
-**AFTER agent reviews:**
+**AFTER agents reviews:**
 1. NEVER claim work is complete without validation
 2. When user requests "review after fixes", actually DO the review
 3. Use Grep to verify each critical fix (pricing, colors, tech stack, etc.)
-4. If approaching context limits, TELL USER instead of rushing
+4. If approaching context limits, TELL USER instead of rushing - never implement short-term solutions - always think long-term scalable solutions.
 
 **Agent review workflow:**
 1. Run agents ONE AT A TIME (never parallel for final reviews)
@@ -137,6 +139,8 @@ Fixing a bug:
 - Instant feedback, optimistic UI updates
 - Privacy-first (on-device ML, minimal server data)
 - Polished animations (spring curves, natural motion)
+- No P0/P1 bugs
+- Users are excited to use the app and know everything just works, is easy to understand, and design is something apple would launch.
 
 ### Zero-Defect Review Protocol (Comprehensive Methodology)
 
@@ -175,7 +179,8 @@ Fixing a bug:
 - Fix ALL issues found (P0, P1, P2) before next cycle - partial fixes cause regression
 - Continue cycles until 2 consecutive show zero P0/P1 issues
 - Only acceptable P2 remaining: test-only issues, documentation suggestions
-- Use agents (code-reviewer, ios-architect, qa-specialist) for comprehensive coverage
+- Use agents (code-reviewer, product-manager, product-designer, ios-architect, qa-specialist) for comprehensive coverage
+- never implement short-term solutions - always think long-term scalable solutions that meet the apple quality bar
 - Document all fixes with clear commit messages
 
 **When Review is Complete:**
@@ -184,6 +189,7 @@ Fixing a bug:
 - All files mentally compile successfully
 - 100% pattern consistency verified across all ViewModels/Views
 - Automation scripts pass (see scripts/check-ios26-patterns.sh)
+- any issues, not deprioritizd to be fixed later (i.e., P2 issues) should be documented in github issues with appropriate labeling
 
 **See Also:**
 - iOS_26_PATTERNS.md - Complete pattern reference guide

--- a/ios-app/FareLens.xcodeproj/project.pbxproj
+++ b/ios-app/FareLens.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 77;
+	objectVersion = 63;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -96,7 +96,7 @@
 		17524802C287C8DBEFC0EB09 /* AuthTokenStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthTokenStore.swift; sourceTree = "<group>"; };
 		180321B81400CEFAEB1ED91F /* PaywallView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaywallView.swift; sourceTree = "<group>"; };
 		19C6D922A353319A95C17487 /* DealsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DealsView.swift; sourceTree = "<group>"; };
-		1B75C10E76277C86A0CAFF3F /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
+		1B75C10E76277C86A0CAFF3F /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
 		1B8D614CA266A4DA4BCC720D /* AlertsRepositoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlertsRepositoryTests.swift; sourceTree = "<group>"; };
 		2069BB3D7431040F6C0F3EAC /* FLButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FLButton.swift; sourceTree = "<group>"; };
 		20DF27A3F0C912E505B21DB5 /* DealDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DealDetailView.swift; sourceTree = "<group>"; };
@@ -117,11 +117,11 @@
 		69263D029AFA8F51AF063627 /* InfoBox.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InfoBox.swift; sourceTree = "<group>"; };
 		753E73E6FF94861A986E57BB /* DealDetailViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DealDetailViewModel.swift; sourceTree = "<group>"; };
 		7A33200F9C341BB8FBEEF9DC /* AlertPreferencesView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlertPreferencesView.swift; sourceTree = "<group>"; };
-		7CDE0955462003CE74DB7237 /* FareLens.app */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.application; path = FareLens.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		7CDE0955462003CE74DB7237 /* FareLens.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = FareLens.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		88087F75DA8A84E6C01147D2 /* Config.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Config.swift; sourceTree = "<group>"; };
 		8DA3969D738954B97706F183 /* WatchlistRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WatchlistRepository.swift; sourceTree = "<group>"; };
 		912442EDFA73A60E5BACADBC /* MainTabView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainTabView.swift; sourceTree = "<group>"; };
-		97C966EA1FD07E16BD36DD8F /* Secrets.xcconfig.local */ = {isa = PBXFileReference; path = Secrets.xcconfig.local; sourceTree = "<group>"; };
+		97C966EA1FD07E16BD36DD8F /* Secrets.xcconfig.local */ = {isa = PBXFileReference; lastKnownFileType = text; path = Secrets.xcconfig.local; sourceTree = "<group>"; };
 		A5FC6C79B3216189BA4E7733 /* Typography.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Typography.swift; sourceTree = "<group>"; };
 		ABE70352116288814E2C56FD /* Spacing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Spacing.swift; sourceTree = "<group>"; };
 		ACCA7D3EE71693299485D505 /* AlertService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlertService.swift; sourceTree = "<group>"; };
@@ -436,13 +436,6 @@
 			path = Persistence;
 			sourceTree = "<group>";
 		};
-		"TEMP_4506ED32-BF23-49A3-B298-06AF6C438A5E" /* Localizations */ = {
-			isa = PBXGroup;
-			children = (
-			);
-			path = Localizations;
-			sourceTree = "<group>";
-		};
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
@@ -514,7 +507,6 @@
 			packageReferences = (
 				2A68864A817C91F5FDE48EC8 /* XCRemoteSwiftPackageReference "supabase-swift" */,
 			);
-			preferredProjectObjectVersion = 77;
 			projectDirPath = "";
 			projectRoot = "";
 			targets = (
@@ -740,6 +732,7 @@
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_ASSET_PATHS = "";
+				DEVELOPMENT_TEAM = CW5S2VLLV4;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = FareLens/Resources/Info.plist;
@@ -766,6 +759,7 @@
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_ASSET_PATHS = "";
+				DEVELOPMENT_TEAM = CW5S2VLLV4;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = FareLens/Resources/Info.plist;

--- a/ios-app/FareLens/Core/Models/Airport.swift
+++ b/ios-app/FareLens/Core/Models/Airport.swift
@@ -58,33 +58,99 @@ actor AirportService {
         isLoaded = true
     }
 
-    /// Search airports by query (matches IATA, city, name, or country)
+    /// Search airports with 5-tier ranking algorithm
+    /// Tier 1: Exact IATA match
+    /// Tier 2: IATA prefix match
+    /// Tier 3: City prefix match
+    /// Tier 4: Contains in name or city
+    /// Tier 5: Fuzzy match (Levenshtein distance ≤ 2)
     func search(query: String) async -> [Airport] {
         // Ensure airports are loaded
         if !isLoaded {
             try? await loadAirports()
         }
 
-        // Return all if query is empty
-        guard !query.isEmpty else {
-            return airports
+        // Minimum query length for performance
+        guard query.count >= 2 else {
+            return []
         }
 
         let lowercaseQuery = query.lowercased()
+        var results: [(airport: Airport, tier: Int)] = []
 
-        // Prioritize IATA code matches, then city matches, then general matches
-        let iataMatches = airports.filter { $0.iata.lowercased().starts(with: lowercaseQuery) }
-        let cityMatches = airports.filter {
-            !$0.iata.lowercased().starts(with: lowercaseQuery) &&
-                $0.city.lowercased().starts(with: lowercaseQuery)
-        }
-        let otherMatches = airports.filter {
-            !$0.iata.lowercased().starts(with: lowercaseQuery) &&
-                !$0.city.lowercased().starts(with: lowercaseQuery) &&
-                $0.searchText.contains(lowercaseQuery)
+        // Single pass through airports with tier assignment
+        for airport in airports {
+            let iata = airport.iata.lowercased()
+            let name = airport.name.lowercased()
+            let city = airport.city.lowercased()
+
+            // Assign tier based on first match (tiers are mutually exclusive)
+            let tier: Int? = {
+                // Tier 1: Exact IATA match
+                if iata == lowercaseQuery {
+                    return 1
+                }
+                // Tier 2: IATA prefix match
+                if iata.hasPrefix(lowercaseQuery) {
+                    return 2
+                }
+                // Tier 3: City prefix match
+                if city.hasPrefix(lowercaseQuery) {
+                    return 3
+                }
+                // Tier 4: Contains in name or city
+                if name.contains(lowercaseQuery) || city.contains(lowercaseQuery) {
+                    return 4
+                }
+                // Tier 5: Fuzzy match (Levenshtein distance ≤ 2)
+                if levenshteinDistance(city, lowercaseQuery) <= 2 {
+                    return 5
+                }
+                return nil
+            }()
+
+            if let tier = tier {
+                results.append((airport, tier))
+            }
         }
 
-        return iataMatches + cityMatches + otherMatches
+        // Sort by tier (lower is better), then alphabetically by city
+        return results
+            .sorted { lhs, rhs in
+                if lhs.tier == rhs.tier {
+                    return lhs.airport.city < rhs.airport.city
+                }
+                return lhs.tier < rhs.tier
+            }
+            .prefix(10) // Limit to 10 results for mobile UX
+            .map { $0.airport }
+    }
+
+    /// Calculate Levenshtein distance between two strings
+    private func levenshteinDistance(_ s1: String, _ s2: String) -> Int {
+        let s1Array = Array(s1)
+        let s2Array = Array(s2)
+        var matrix = [[Int]](repeating: [Int](repeating: 0, count: s2Array.count + 1), count: s1Array.count + 1)
+
+        for i in 0...s1Array.count {
+            matrix[i][0] = i
+        }
+        for j in 0...s2Array.count {
+            matrix[0][j] = j
+        }
+
+        for i in 1...s1Array.count {
+            for j in 1...s2Array.count {
+                let cost = s1Array[i - 1] == s2Array[j - 1] ? 0 : 1
+                matrix[i][j] = Swift.min(
+                    matrix[i - 1][j] + 1,      // deletion
+                    matrix[i][j - 1] + 1,      // insertion
+                    matrix[i - 1][j - 1] + cost // substitution
+                )
+            }
+        }
+
+        return matrix[s1Array.count][s2Array.count]
     }
 
     /// Get airport by IATA code

--- a/ios-app/FareLens/DesignSystem/Components/ErrorBanner.swift
+++ b/ios-app/FareLens/DesignSystem/Components/ErrorBanner.swift
@@ -4,16 +4,23 @@
 import SwiftUI
 
 /// Screen-level error banner for server/network errors
-/// Shows error icon, message, and optional action button
+/// Shows error icon, message, and optional retry/dismiss actions
 struct ErrorBanner: View {
     let message: String
     let actionTitle: String?
     let action: (() -> Void)?
+    let onDismiss: (() -> Void)?
 
-    init(message: String, actionTitle: String? = nil, action: (() -> Void)? = nil) {
+    init(
+        message: String,
+        actionTitle: String? = nil,
+        action: (() -> Void)? = nil,
+        onDismiss: (() -> Void)? = nil
+    ) {
         self.message = message
         self.actionTitle = actionTitle
         self.action = action
+        self.onDismiss = onDismiss
     }
 
     var body: some View {
@@ -28,11 +35,31 @@ struct ErrorBanner: View {
                     .foregroundColor(.textPrimary)
                     .fixedSize(horizontal: false, vertical: true)
 
-                if let actionTitle {
-                    Button(action: { action?() }) {
-                        Text(actionTitle)
-                            .footnoteStyle()
-                            .foregroundColor(.brandBlue)
+                // Action buttons row
+                if actionTitle != nil || onDismiss != nil {
+                    HStack(spacing: Spacing.md) {
+                        if let actionTitle {
+                            Button(action: {
+                                let generator = UIImpactFeedbackGenerator(style: .medium)
+                                generator.impactOccurred()
+                                action?()
+                            }) {
+                                Text(actionTitle)
+                                    .footnoteStyle()
+                                    .fontWeight(.semibold)
+                                    .foregroundColor(.brandBlue)
+                            }
+                        }
+
+                        if onDismiss != nil {
+                            Button(action: {
+                                onDismiss?()
+                            }) {
+                                Text("Dismiss")
+                                    .footnoteStyle()
+                                    .foregroundColor(.textSecondary)
+                            }
+                        }
                     }
                 }
             }
@@ -59,17 +86,22 @@ struct ErrorBanner: View {
     VStack(spacing: Spacing.lg) {
         ErrorBanner(
             message: "Unable to connect. Please check your internet connection and try again.",
-            actionTitle: "Try Again"
-        ) {
-            // Retry action
-        }
+            actionTitle: "Try Again",
+            action: {
+                // Retry action
+            },
+            onDismiss: {
+                // Dismiss action
+            }
+        )
 
         ErrorBanner(
             message: "An account with this email already exists. Try signing in instead.",
-            actionTitle: "Go to Sign In"
-        ) {
-            // Switch to sign in action
-        }
+            actionTitle: "Go to Sign In",
+            action: {
+                // Switch to sign in action
+            }
+        )
 
         ErrorBanner(
             message: "The email or password you entered is incorrect. Please try again."

--- a/ios-app/FareLens/DesignSystem/Components/FLButton.swift
+++ b/ios-app/FareLens/DesignSystem/Components/FLButton.swift
@@ -3,8 +3,22 @@
 
 import SwiftUI
 
+// MARK: - Press Animation Button Style
+
+/// Button style that applies a subtle scale animation on press
+/// Following Apple's HIG for tactile feedback (0.96x scale)
+struct PressAnimationButtonStyle: SwiftUI.ButtonStyle {
+    func makeBody(configuration: Configuration) -> some View {
+        configuration.label
+            .scaleEffect(configuration.isPressed ? 0.96 : 1.0)
+            .animation(.spring(response: 0.2, dampingFraction: 0.7), value: configuration.isPressed)
+    }
+}
+
+// MARK: - FLButton
+
 /// FareLens Button Component
-/// Consistent button styling across the app
+/// Consistent button styling across the app with press animations
 struct FLButton: View {
     let title: String
     let style: ButtonStyle
@@ -21,6 +35,7 @@ struct FLButton: View {
                 .background(style.background)
                 .cornerRadius(CornerRadius.sm)
         }
+        .buttonStyle(PressAnimationButtonStyle())
     }
 
     enum ButtonStyle {

--- a/ios-app/FareLens/DesignSystem/Components/FLCompactButton.swift
+++ b/ios-app/FareLens/DesignSystem/Components/FLCompactButton.swift
@@ -32,5 +32,6 @@ struct FLCompactButton: View {
             .background(Color.cardBackground)
             .cornerRadius(CornerRadius.sm)
         }
+        .buttonStyle(PressAnimationButtonStyle())
     }
 }

--- a/ios-app/FareLens/DesignSystem/Components/FLIconButton.swift
+++ b/ios-app/FareLens/DesignSystem/Components/FLIconButton.swift
@@ -18,5 +18,6 @@ struct FLIconButton: View {
                 .background(Color.cardBackground)
                 .cornerRadius(CornerRadius.sm)
         }
+        .buttonStyle(PressAnimationButtonStyle())
     }
 }

--- a/ios-app/FareLens/DesignSystem/Components/ValidationMessage.swift
+++ b/ios-app/FareLens/DesignSystem/Components/ValidationMessage.swift
@@ -1,0 +1,83 @@
+// FareLens - Flight Deal Alert App
+// Copyright © 2025 FareLens. All rights reserved.
+
+import SwiftUI
+
+/// Validation message component for form feedback
+/// Purpose-built for inline validation with proper animations and accessibility
+struct ValidationMessage: View {
+    let message: String
+    let severity: Severity
+
+    enum Severity {
+        case error
+        case warning
+        case info
+
+        var icon: String {
+            switch self {
+            case .error: return "exclamationmark.triangle.fill"
+            case .warning: return "exclamationmark.circle.fill"
+            case .info: return "info.circle.fill"
+            }
+        }
+
+        var color: Color {
+            switch self {
+            case .error: return .error
+            case .warning: return .warning
+            case .info: return .brandBlue
+            }
+        }
+    }
+
+    var body: some View {
+        HStack(spacing: Spacing.sm) {
+            Image(systemName: severity.icon)
+                .font(.caption)
+                .foregroundColor(severity.color)
+
+            Text(message)
+                .footnoteStyle()
+                .foregroundColor(.textPrimary)
+                .fixedSize(horizontal: false, vertical: true)
+
+            Spacer(minLength: 0)
+        }
+        .padding(.horizontal, Spacing.md)
+        .padding(.vertical, Spacing.sm)
+        .background(severity.color.opacity(0.1))
+        .cornerRadius(CornerRadius.sm)
+        .transition(.asymmetric(
+            insertion: .move(edge: .top).combined(with: .opacity),
+            removal: .opacity
+        ))
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("\(severity == .error ? "Error" : severity == .warning ? "Warning" : "Information"): \(message)")
+    }
+}
+
+// MARK: - Preview
+
+struct ValidationMessage_Previews: PreviewProvider {
+    static var previews: some View {
+        VStack(spacing: Spacing.lg) {
+            ValidationMessage(
+                message: "Current total: 0.8 - Add 0.2 more to reach 1.0",
+                severity: .error
+            )
+
+            ValidationMessage(
+                message: "Almost there! Current total: 0.95",
+                severity: .warning
+            )
+
+            ValidationMessage(
+                message: "Weights are valid and ready to save",
+                severity: .info
+            )
+        }
+        .padding()
+        .background(Color.backgroundPrimary)
+    }
+}

--- a/ios-app/FareLens/DesignSystem/Theme/Animations.swift
+++ b/ios-app/FareLens/DesignSystem/Theme/Animations.swift
@@ -1,0 +1,23 @@
+// FareLens - Flight Deal Alert App
+// Copyright © 2025 FareLens. All rights reserved.
+
+import SwiftUI
+
+/// Reusable animation presets for consistent motion across the app
+/// Following Apple's design principles for natural, predictable animations
+extension Animation {
+    /// Fast, snappy animation for buttons and small UI changes
+    /// Response: 0.3s, Damping: 0.7
+    /// Use for: Button presses, toggles, small state changes
+    static let uiSnappy = Animation.spring(response: 0.3, dampingFraction: 0.7)
+
+    /// Standard animation for most UI transitions
+    /// Response: 0.4s, Damping: 0.75
+    /// Use for: Form validation, modal presentation, content updates
+    static let uiStandard = Animation.spring(response: 0.4, dampingFraction: 0.75)
+
+    /// Smooth animation for large view transitions
+    /// Response: 0.5s, Damping: 0.8
+    /// Use for: Screen transitions, large content changes, empty states
+    static let uiSmooth = Animation.spring(response: 0.5, dampingFraction: 0.8)
+}

--- a/ios-app/FareLens/Features/Alerts/AlertsView.swift
+++ b/ios-app/FareLens/Features/Alerts/AlertsView.swift
@@ -6,6 +6,7 @@ import SwiftUI
 struct AlertsView: View {
     @State var viewModel: AlertsViewModel
     @State private var selectedFilter: AlertFilter = .all
+    @State private var showingAlertPreferences = false
 
     var body: some View {
         NavigationView {
@@ -64,13 +65,18 @@ struct AlertsView: View {
             .toolbar {
                 ToolbarItem(placement: .navigationBarTrailing) {
                     Button(action: {
-                        // Navigate to alert preferences
+                        showingAlertPreferences = true
                     }) {
                         Image(systemName: "gear")
                             .foregroundColor(.brandBlue)
                     }
+                    .accessibilityLabel("Alert settings")
+                    .accessibilityHint("Double tap to configure alert preferences")
                 }
             }
+        }
+        .sheet(isPresented: $showingAlertPreferences) {
+            AlertPreferencesView(viewModel: SettingsViewModel(user: viewModel.user))
         }
         .task {
             await viewModel.loadAlerts()
@@ -157,7 +163,7 @@ struct TodayAlertCounter: View {
                         .frame(width: 56, height: 56)
 
                     Circle()
-                        .trim(from: 0, to: CGFloat(sent) / CGFloat(limit))
+                        .trim(from: 0, to: limit > 0 ? CGFloat(sent) / CGFloat(limit) : 0)
                         .stroke(progressColor, lineWidth: 6)
                         .frame(width: 56, height: 56)
                         .rotationEffect(.degrees(-90))
@@ -171,6 +177,7 @@ struct TodayAlertCounter: View {
     }
 
     private var progressColor: Color {
+        guard limit > 0 else { return .textTertiary }
         let percentage = Double(sent) / Double(limit)
         if percentage >= 1.0 {
             return .error

--- a/ios-app/FareLens/Features/Alerts/AlertsView.swift
+++ b/ios-app/FareLens/Features/Alerts/AlertsView.swift
@@ -5,6 +5,7 @@ import SwiftUI
 
 struct AlertsView: View {
     @State var viewModel: AlertsViewModel
+    @Environment(AppState.self) var appState: AppState
     @State private var selectedFilter: AlertFilter = .all
     @State private var showingAlertPreferences = false
 
@@ -76,9 +77,11 @@ struct AlertsView: View {
             }
         }
         .sheet(isPresented: $showingAlertPreferences) {
-            AlertPreferencesView(viewModel: SettingsViewModel(user: viewModel.user))
-                .presentationDetents([.medium, .large])
-                .presentationDragIndicator(.visible)
+            if let user = appState.currentUser {
+                AlertPreferencesView(viewModel: SettingsViewModel(user: user))
+                    .presentationDetents([.medium, .large])
+                    .presentationDragIndicator(.visible)
+            }
         }
         .task {
             await viewModel.loadAlerts()

--- a/ios-app/FareLens/Features/Alerts/AlertsView.swift
+++ b/ios-app/FareLens/Features/Alerts/AlertsView.swift
@@ -77,6 +77,8 @@ struct AlertsView: View {
         }
         .sheet(isPresented: $showingAlertPreferences) {
             AlertPreferencesView(viewModel: SettingsViewModel(user: viewModel.user))
+                .presentationDetents([.medium, .large])
+                .presentationDragIndicator(.visible)
         }
         .task {
             await viewModel.loadAlerts()
@@ -118,8 +120,13 @@ struct FilterChip: View {
     let isSelected: Bool
     let onTap: () -> Void
 
+    private let impactGenerator = UIImpactFeedbackGenerator(style: .light)
+
     var body: some View {
-        Button(action: onTap) {
+        Button(action: {
+            impactGenerator.impactOccurred()
+            onTap()
+        }) {
             Text(title)
                 .footnoteStyle()
                 .foregroundColor(isSelected ? .white : .textPrimary)
@@ -127,6 +134,9 @@ struct FilterChip: View {
                 .padding(.vertical, Spacing.sm)
                 .background(isSelected ? Color.brandBlue : Color.cardBackground)
                 .cornerRadius(CornerRadius.sm)
+        }
+        .onAppear {
+            impactGenerator.prepare()
         }
     }
 }
@@ -172,6 +182,10 @@ struct TodayAlertCounter: View {
                         .headlineStyle()
                         .foregroundColor(.textPrimary)
                 }
+                .accessibilityElement(children: .combine)
+                .accessibilityLabel("Daily alerts")
+                .accessibilityValue("\(sent) of \(limit) sent, \(limit > 0 ? Int((Double(sent) / Double(limit)) * 100) : 0) percent used")
+                .accessibilityHint(sent >= limit ? "Daily limit reached" : "\(limit - sent) alerts remaining today")
             }
         }
     }

--- a/ios-app/FareLens/Features/Alerts/AlertsView.swift
+++ b/ios-app/FareLens/Features/Alerts/AlertsView.swift
@@ -311,6 +311,43 @@ struct EmptyAlertsView: View {
                     .multilineTextAlignment(.center)
             }
 
+            // Onboarding Checklist (only for "all" filter)
+            if filter == .all {
+                VStack(alignment: .leading, spacing: Spacing.md) {
+                    Text("Get Started")
+                        .headlineStyle()
+                        .foregroundColor(.textPrimary)
+
+                    OnboardingChecklistItem(
+                        icon: "list.bullet.clipboard",
+                        title: "Create a watchlist",
+                        subtitle: "Track flight deals from your favorite routes"
+                    )
+
+                    OnboardingChecklistItem(
+                        icon: "bell.badge",
+                        title: "Enable push notifications",
+                        subtitle: "Get instant alerts when deals appear"
+                    )
+
+                    OnboardingChecklistItem(
+                        icon: "slider.horizontal.3",
+                        title: "Set your alert preferences",
+                        subtitle: "Customize how often you want to hear from us"
+                    )
+
+                    OnboardingChecklistItem(
+                        icon: "sparkles",
+                        title: "Sit back and relax",
+                        subtitle: "We'll monitor deals and notify you automatically"
+                    )
+                }
+                .padding(Spacing.md)
+                .background(Color.cardBackground)
+                .cornerRadius(CornerRadius.md)
+                .padding(.horizontal, Spacing.sm)
+            }
+
             FLButton(title: "Adjust Alert Settings", style: .secondary) {
                 // Navigate to alert preferences
             }
@@ -329,6 +366,38 @@ struct EmptyAlertsView: View {
             "this week"
         case .thisMonth:
             "this month"
+        }
+    }
+}
+
+// MARK: - Onboarding Checklist Item
+
+private struct OnboardingChecklistItem: View {
+    let icon: String
+    let title: String
+    let subtitle: String
+
+    var body: some View {
+        HStack(spacing: Spacing.md) {
+            Image(systemName: icon)
+                .font(.title3)
+                .foregroundColor(.brandBlue)
+                .frame(width: 32, height: 32)
+                .background(Color.brandBlue.opacity(0.1))
+                .cornerRadius(CornerRadius.sm)
+
+            VStack(alignment: .leading, spacing: Spacing.xs) {
+                Text(title)
+                    .bodyStyle()
+                    .fontWeight(.semibold)
+                    .foregroundColor(.textPrimary)
+
+                Text(subtitle)
+                    .footnoteStyle()
+                    .foregroundColor(.textSecondary)
+            }
+
+            Spacer()
         }
     }
 }

--- a/ios-app/FareLens/Features/Deals/DealsView.swift
+++ b/ios-app/FareLens/Features/Deals/DealsView.swift
@@ -132,26 +132,49 @@ struct EmptyDealsView: View {
     let watchlistsViewModel: WatchlistsViewModel?
     let onCreateWatchlist: () -> Void
 
+    private var hasWatchlists: Bool {
+        guard let viewModel = watchlistsViewModel else { return false }
+        return !viewModel.watchlists.isEmpty
+    }
+
     var body: some View {
         VStack(spacing: Spacing.xl) {
-            Image(systemName: "airplane.departure")
+            Image(systemName: hasWatchlists ? "bell.slash" : "airplane.departure")
                 .font(.system(size: 64))
                 .foregroundColor(.brandBlue.opacity(0.5))
 
             VStack(spacing: Spacing.sm) {
-                Text("No deals right now")
+                Text(hasWatchlists ? "No deals found" : "No deals right now")
                     .title2Style()
                     .foregroundColor(.textPrimary)
 
-                Text("We're scanning thousands of flights.\nCheck back soon for amazing deals!")
+                Text(hasWatchlists
+                    ? "We're actively monitoring your watchlists.\nYou'll be notified when deals appear!"
+                    : "Create a watchlist to start tracking\nflight deals from your favorite routes")
                     .bodyStyle()
                     .foregroundColor(.textSecondary)
                     .multilineTextAlignment(.center)
             }
 
-            FLButton(title: "Create Watchlist", style: .secondary, action: onCreateWatchlist)
-                .disabled(watchlistsViewModel == nil)
-                .opacity(watchlistsViewModel == nil ? 0.5 : 1.0)
+            // Context-aware CTA
+            if hasWatchlists {
+                VStack(spacing: Spacing.md) {
+                    // Secondary action: Add another watchlist
+                    if let viewModel = watchlistsViewModel, viewModel.canAddWatchlist {
+                        FLButton(title: "Add Another Watchlist", style: .secondary, action: onCreateWatchlist)
+                    }
+
+                    // Helpful tip
+                    InfoBox(
+                        icon: "lightbulb.fill",
+                        text: "Tip: Deals appear based on your watchlist criteria. Try adjusting your routes or destinations for more results."
+                    )
+                }
+            } else {
+                FLButton(title: "Create Watchlist", style: .primary, action: onCreateWatchlist)
+                    .disabled(watchlistsViewModel == nil)
+                    .opacity(watchlistsViewModel == nil ? 0.5 : 1.0)
+            }
         }
         .padding(Spacing.screenHorizontal)
     }

--- a/ios-app/FareLens/Features/Settings/PreferredAirportsView.swift
+++ b/ios-app/FareLens/Features/Settings/PreferredAirportsView.swift
@@ -68,12 +68,44 @@ struct PreferredAirportsView: View {
                                 .foregroundColor(.error)
                         }
 
-                        FLButton(title: "Save Changes", style: .primary) {
-                            Task {
-                                await viewModel.updatePreferredAirports()
+                        Group {
+                            if viewModel.isSaving {
+                                // Loading state
+                                HStack(spacing: Spacing.sm) {
+                                    ProgressView()
+                                        .tint(.white)
+                                    Text("Saving...")
+                                        .headlineStyle()
+                                        .foregroundColor(.white)
+                                }
+                                .frame(maxWidth: .infinity)
+                                .padding(.vertical, Spacing.buttonVertical)
+                                .background(Color.brandBlue)
+                                .cornerRadius(CornerRadius.md)
+                            } else if viewModel.showSaveSuccess {
+                                // Success state
+                                HStack(spacing: Spacing.sm) {
+                                    Image(systemName: "checkmark.circle.fill")
+                                        .foregroundColor(.white)
+                                        .font(.title3)
+                                    Text("Saved")
+                                        .headlineStyle()
+                                        .foregroundColor(.white)
+                                }
+                                .frame(maxWidth: .infinity)
+                                .padding(.vertical, Spacing.buttonVertical)
+                                .background(Color.success)
+                                .cornerRadius(CornerRadius.md)
+                            } else {
+                                // Normal state
+                                FLButton(title: "Save Changes", style: .primary) {
+                                    Task {
+                                        await viewModel.updatePreferredAirports()
+                                    }
+                                }
+                                .disabled(!viewModel.isWeightSumValid)
                             }
                         }
-                        .disabled(!viewModel.isWeightSumValid)
                         .padding(.horizontal, Spacing.screenHorizontal)
                     }
                     .padding(.vertical, Spacing.md)

--- a/ios-app/FareLens/Features/Settings/PreferredAirportsView.swift
+++ b/ios-app/FareLens/Features/Settings/PreferredAirportsView.swift
@@ -69,7 +69,12 @@ struct PreferredAirportsView: View {
                     EmptyAirportsView {
                         showingAddAirport = true
                     }
+                    .transition(.asymmetric(
+                        insertion: .scale(scale: 0.9).combined(with: .opacity),
+                        removal: .scale(scale: 0.9).combined(with: .opacity)
+                    ))
                 }
+                .animation(.spring(response: 0.5, dampingFraction: 0.8), value: viewModel.preferredAirports.isEmpty)
 
                 // Save Button
                 if !viewModel.preferredAirports.isEmpty {
@@ -94,12 +99,17 @@ struct PreferredAirportsView: View {
                                 .padding(.vertical, Spacing.buttonVertical)
                                 .background(Color.brandBlue)
                                 .cornerRadius(CornerRadius.md)
+                                .transition(.asymmetric(
+                                    insertion: .scale(scale: 0.95).combined(with: .opacity),
+                                    removal: .scale(scale: 1.05).combined(with: .opacity)
+                                ))
                             } else if viewModel.showSaveSuccess {
-                                // Success state
+                                // Success state with checkmark animation
                                 HStack(spacing: Spacing.sm) {
                                     Image(systemName: "checkmark.circle.fill")
                                         .foregroundColor(.white)
                                         .font(.title3)
+                                        .symbolEffect(.bounce, value: viewModel.showSaveSuccess)
                                     Text("Saved")
                                         .headlineStyle()
                                         .foregroundColor(.white)
@@ -108,6 +118,10 @@ struct PreferredAirportsView: View {
                                 .padding(.vertical, Spacing.buttonVertical)
                                 .background(Color.success)
                                 .cornerRadius(CornerRadius.md)
+                                .transition(.asymmetric(
+                                    insertion: .scale(scale: 0.95).combined(with: .opacity),
+                                    removal: .scale(scale: 0.95).combined(with: .opacity)
+                                ))
                             } else {
                                 // Normal state
                                 FLButton(title: "Save Changes", style: .primary) {
@@ -116,8 +130,11 @@ struct PreferredAirportsView: View {
                                     }
                                 }
                                 .disabled(!viewModel.isWeightSumValid)
+                                .transition(.scale(scale: 0.95).combined(with: .opacity))
                             }
                         }
+                        .animation(.spring(response: 0.4, dampingFraction: 0.75), value: viewModel.isSaving)
+                        .animation(.spring(response: 0.4, dampingFraction: 0.75), value: viewModel.showSaveSuccess)
                         .padding(.horizontal, Spacing.screenHorizontal)
                     }
                     .padding(.vertical, Spacing.md)

--- a/ios-app/FareLens/Features/Settings/PreferredAirportsView.swift
+++ b/ios-app/FareLens/Features/Settings/PreferredAirportsView.swift
@@ -189,6 +189,8 @@ struct AirportWeightRow: View {
     let onDelete: () -> Void
     let onUpgradeTap: () -> Void
 
+    private let selectionFeedback = UISelectionFeedbackGenerator()
+
     var body: some View {
         VStack(alignment: .leading, spacing: Spacing.md) {
             HStack {
@@ -232,13 +234,22 @@ struct AirportWeightRow: View {
 
                     Slider(value: Binding(
                         get: { weight },
-                        set: { onWeightChange($0) }
+                        set: { newWeight in
+                            // Light haptic feedback on value change (Pro users only)
+                            if isProUser, newWeight != weight {
+                                selectionFeedback.selectionChanged()
+                            }
+                            onWeightChange(newWeight)
+                        }
                     ), in: 0.0...1.0, step: 0.1)
                         .tint(isProUser ? .brandBlue : .textTertiary.opacity(0.3))
                         .disabled(!isProUser)
                         .accessibilityLabel("Airport weight")
                         .accessibilityValue("\(Int(weight * 100)) percent")
                         .accessibilityHint(isProUser ? "Adjust to change priority" : "Upgrade to Pro to customize weights")
+                        .onAppear {
+                            selectionFeedback.prepare()
+                        }
                 }
 
                 HStack {

--- a/ios-app/FareLens/Features/Settings/SettingsViewModel.swift
+++ b/ios-app/FareLens/Features/Settings/SettingsViewModel.swift
@@ -91,6 +91,9 @@ final class SettingsViewModel {
             // Show success feedback
             showSaveSuccess = true
 
+            // VoiceOver announcement for save success
+            UIAccessibility.post(notification: .announcement, argument: "Preferred airports saved successfully")
+
             // Optimized haptic timing - delay 50ms to coincide with visual update
             Task { @MainActor in
                 try? await Task.sleep(for: .milliseconds(50))
@@ -116,11 +119,17 @@ final class SettingsViewModel {
                 errorMessage = "Failed to save airports. Please try again."
             }
             feedbackGenerator.notificationOccurred(.error)
+            // VoiceOver announcement for error
+            if let errorMsg = errorMessage {
+                UIAccessibility.post(notification: .announcement, argument: errorMsg)
+            }
         } catch {
             // Other errors (API errors, etc.)
             // TODO: Add typed error handling for APIError when available
             errorMessage = "Failed to save airports. Please try again."
             feedbackGenerator.notificationOccurred(.error)
+            // VoiceOver announcement for error
+            UIAccessibility.post(notification: .announcement, argument: errorMessage ?? "Save failed")
         }
     }
 

--- a/ios-app/FareLens/Features/Settings/SettingsViewModel.swift
+++ b/ios-app/FareLens/Features/Settings/SettingsViewModel.swift
@@ -17,7 +17,8 @@ final class SettingsViewModel {
     var errorMessage: String?
     var showingUpgradeSheet = false
 
-    private var dismissSuccessTask: Task<Void, Never>?
+    // Task cancellation is thread-safe, so can be accessed from nonisolated deinit
+    nonisolated(unsafe) private var dismissSuccessTask: Task<Void, Never>?
     private let feedbackGenerator = UINotificationFeedbackGenerator()
 
     init(user: User) {


### PR DESCRIPTION
## Summary
Implements #165 - Adds comprehensive user feedback to the Preferred Airports save flow with loading states, success confirmation, and haptic feedback.

## Changes

### SettingsViewModel.swift
- Added `isSaving` state to track save operation in progress
- Added `showSaveSuccess` state for success confirmation display
- Enhanced `updatePreferredAirports()` with:
  - Loading state management
  - Success feedback with auto-dismiss after 2 seconds
  - Haptic feedback on successful save
  - Specific error messages (network, unauthorized, generic)

### PreferredAirportsView.swift
- Updated Save button to show three states:
  - **Normal**: "Save Changes" button (disabled if weights invalid)
  - **Loading**: Spinner + "Saving..." text
  - **Success**: Checkmark + "Saved" text (green background)
- Smooth state transitions with automatic reset

## UX Flow
1. User modifies airport weights
2. Taps "Save Changes" → Button shows spinner + "Saving..."
3. On success:
   - Button turns green with checkmark + "Saved"
   - Device vibrates (success haptic)
   - Auto-dismisses after 2 seconds
4. On error: Shows specific error message above button

## Test Plan
- [ ] Verify "Saving..." state appears when save is initiated
- [ ] Verify success state appears with checkmark and green background
- [ ] Verify haptic feedback occurs on successful save
- [ ] Verify success state auto-dismisses after 2 seconds
- [ ] Test network error shows appropriate message
- [ ] Test invalid weight sum still shows validation error
- [ ] Verify Free tier users see simplified UI (from #164)

🤖 Generated with [Claude Code](https://claude.com/claude-code)